### PR TITLE
feat: implement core UI CRUD flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,17 @@ State actions implemented in reducer/store:
 - complete
 - reopen
 - delete
+
+## Core UI flows (Issue #7)
+Implemented in the app UI:
+- Create task form with title validation and optional description.
+- Task list with empty states.
+- Update flows: edit, complete/reopen.
+- Delete flow.
+- Visually distinct status badges/cards for open vs completed tasks.
+- Baseline list controls: search (title/description), status filter, and sort.
+
+Deferred to later issues:
+- Persistence (Issue #8)
+- Responsive refinements (Issue #9)
+- Novel differentiator feature (Issue #11)

--- a/src/App.css
+++ b/src/App.css
@@ -1,18 +1,157 @@
 .app {
-  min-height: 100vh;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1.5rem;
   display: grid;
-  place-content: center;
-  text-align: center;
-  gap: 0.5rem;
-  padding: 2rem;
+  gap: 1rem;
 }
 
 .app h1 {
   margin: 0;
-  font-size: 2rem;
 }
 
-.app p {
+.panel {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.panel h2 {
+  margin-top: 0;
+}
+
+.task-form,
+.task-edit {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.controls {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  margin-bottom: 1rem;
+}
+
+label {
+  font-size: 0.875rem;
+  color: #334155;
+}
+
+input,
+textarea,
+select,
+button {
+  font: inherit;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+}
+
+button {
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: #fff;
+  border-radius: 8px;
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+}
+
+button.secondary {
+  background: #fff;
+  color: #0f172a;
+}
+
+button.danger {
+  background: #7f1d1d;
+  border-color: #7f1d1d;
+}
+
+.task-list {
+  display: grid;
+  gap: 0.75rem;
   margin: 0;
-  color: #444;
+  padding: 0;
+  list-style: none;
+}
+
+.task-item {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #f8fafc;
+}
+
+.task-item--completed {
+  border-color: #86efac;
+  background: #f0fdf4;
+}
+
+.task-item--open {
+  border-color: #93c5fd;
+  background: #eff6ff;
+}
+
+.task-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.task-header h3 {
+  margin: 0;
+}
+
+.status-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+}
+
+.status-badge--open {
+  color: #1d4ed8;
+  background: #dbeafe;
+}
+
+.status-badge--completed {
+  color: #166534;
+  background: #dcfce7;
+}
+
+.task-description {
+  margin: 0.5rem 0;
+  color: #334155;
+}
+
+.task-meta {
+  margin: 0;
+  color: #475569;
+  font-size: 0.875rem;
+}
+
+.task-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.empty-state {
+  margin: 0 0 0.75rem;
+  color: #475569;
+}
+
+.error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.875rem;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,289 @@
+import { useMemo, useReducer, useState } from 'react';
 import './App.css';
+import {
+  completeTaskAction,
+  createTaskAction,
+  deleteTaskAction,
+  editTaskAction,
+  initialTasksState,
+  reopenTaskAction,
+  tasksReducer
+} from './state/tasks';
+
+const STATUS_FILTERS = {
+  ALL: 'all',
+  OPEN: 'open',
+  COMPLETED: 'completed'
+};
+
+const SORT_OPTIONS = {
+  UPDATED_DESC: 'updated-desc',
+  CREATED_DESC: 'created-desc',
+  CREATED_ASC: 'created-asc',
+  TITLE_ASC: 'title-asc'
+};
+
+function normalizeDescription(description) {
+  const trimmed = description.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function byDateDesc(a, b, field) {
+  return new Date(b[field]).getTime() - new Date(a[field]).getTime();
+}
+
+function selectVisibleTasks(tasks, { query, statusFilter, sortBy }) {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filtered = tasks.filter((task) => {
+    if (statusFilter !== STATUS_FILTERS.ALL && task.status !== statusFilter) {
+      return false;
+    }
+
+    if (!normalizedQuery) {
+      return true;
+    }
+
+    const haystack = [task.title, task.description ?? ''].join(' ').toLowerCase();
+    return haystack.includes(normalizedQuery);
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    switch (sortBy) {
+      case SORT_OPTIONS.CREATED_DESC:
+        return byDateDesc(a, b, 'createdAt');
+      case SORT_OPTIONS.CREATED_ASC:
+        return -byDateDesc(a, b, 'createdAt');
+      case SORT_OPTIONS.TITLE_ASC:
+        return a.title.localeCompare(b.title);
+      case SORT_OPTIONS.UPDATED_DESC:
+      default:
+        return byDateDesc(a, b, 'updatedAt');
+    }
+  });
+
+  return sorted;
+}
 
 function App() {
+  const [state, dispatch] = useReducer(tasksReducer, initialTasksState);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [createError, setCreateError] = useState('');
+  const [query, setQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState(STATUS_FILTERS.ALL);
+  const [sortBy, setSortBy] = useState(SORT_OPTIONS.UPDATED_DESC);
+
+  const [editingTaskId, setEditingTaskId] = useState(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editError, setEditError] = useState('');
+
+  const visibleTasks = useMemo(
+    () =>
+      selectVisibleTasks(state.tasks, {
+        query,
+        statusFilter,
+        sortBy
+      }),
+    [query, sortBy, state.tasks, statusFilter]
+  );
+
+  function handleCreate(event) {
+    event.preventDefault();
+
+    try {
+      dispatch(
+        createTaskAction({
+          title,
+          description: normalizeDescription(description)
+        })
+      );
+      setTitle('');
+      setDescription('');
+      setCreateError('');
+    } catch (error) {
+      setCreateError(error.message);
+    }
+  }
+
+  function startEdit(task) {
+    setEditingTaskId(task.id);
+    setEditTitle(task.title);
+    setEditDescription(task.description ?? '');
+    setEditError('');
+  }
+
+  function cancelEdit() {
+    setEditingTaskId(null);
+    setEditTitle('');
+    setEditDescription('');
+    setEditError('');
+  }
+
+  function saveEdit(taskId) {
+    try {
+      dispatch(
+        editTaskAction({
+          id: taskId,
+          title: editTitle,
+          description: normalizeDescription(editDescription)
+        })
+      );
+      cancelEdit();
+    } catch (error) {
+      setEditError(error.message);
+    }
+  }
+
+  function toggleCompleted(task) {
+    dispatch(
+      task.status === 'completed' ? reopenTaskAction({ id: task.id }) : completeTaskAction({ id: task.id })
+    );
+  }
+
   return (
     <main className="app">
       <h1>Novel Task Tracker</h1>
-      <p>React scaffold is ready for Issue #5.</p>
+
+      <section className="panel" aria-label="Create task">
+        <h2>Add task</h2>
+        <form onSubmit={handleCreate} className="task-form">
+          <label htmlFor="task-title">Title</label>
+          <input
+            id="task-title"
+            name="task-title"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="What do you need to do?"
+          />
+
+          <label htmlFor="task-description">Description (optional)</label>
+          <textarea
+            id="task-description"
+            name="task-description"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            rows={3}
+            placeholder="Add context or notes"
+          />
+
+          {createError ? (
+            <p className="error" role="alert">
+              {createError}
+            </p>
+          ) : null}
+
+          <button type="submit">Add task</button>
+        </form>
+      </section>
+
+      <section className="panel" aria-label="Filter and sort tasks">
+        <h2>Tasks</h2>
+        <div className="controls">
+          <label htmlFor="search-tasks">Search</label>
+          <input
+            id="search-tasks"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search title or description"
+          />
+
+          <label htmlFor="status-filter">Status</label>
+          <select
+            id="status-filter"
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.target.value)}
+          >
+            <option value={STATUS_FILTERS.ALL}>All</option>
+            <option value={STATUS_FILTERS.OPEN}>Open</option>
+            <option value={STATUS_FILTERS.COMPLETED}>Completed</option>
+          </select>
+
+          <label htmlFor="sort-by">Sort</label>
+          <select id="sort-by" value={sortBy} onChange={(event) => setSortBy(event.target.value)}>
+            <option value={SORT_OPTIONS.UPDATED_DESC}>Recently updated</option>
+            <option value={SORT_OPTIONS.CREATED_DESC}>Newest first</option>
+            <option value={SORT_OPTIONS.CREATED_ASC}>Oldest first</option>
+            <option value={SORT_OPTIONS.TITLE_ASC}>Title A-Z</option>
+          </select>
+        </div>
+
+        {state.tasks.length === 0 ? (
+          <p className="empty-state">No tasks yet. Add your first task to get started.</p>
+        ) : null}
+
+        {state.tasks.length > 0 && visibleTasks.length === 0 ? (
+          <p className="empty-state">No tasks match your current search or filters.</p>
+        ) : null}
+
+        <ul className="task-list" aria-label="Task list">
+          {visibleTasks.map((task) => {
+            const isEditing = editingTaskId === task.id;
+            const isCompleted = task.status === 'completed';
+
+            return (
+              <li key={task.id} className={`task-item ${isCompleted ? 'task-item--completed' : 'task-item--open'}`}>
+                {isEditing ? (
+                  <div className="task-edit">
+                    <label htmlFor={`edit-title-${task.id}`}>Edit title</label>
+                    <input
+                      id={`edit-title-${task.id}`}
+                      value={editTitle}
+                      onChange={(event) => setEditTitle(event.target.value)}
+                    />
+
+                    <label htmlFor={`edit-description-${task.id}`}>Edit description</label>
+                    <textarea
+                      id={`edit-description-${task.id}`}
+                      rows={3}
+                      value={editDescription}
+                      onChange={(event) => setEditDescription(event.target.value)}
+                    />
+
+                    {editError ? (
+                      <p className="error" role="alert">
+                        {editError}
+                      </p>
+                    ) : null}
+
+                    <div className="task-actions">
+                      <button type="button" onClick={() => saveEdit(task.id)}>
+                        Save
+                      </button>
+                      <button type="button" className="secondary" onClick={cancelEdit}>
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="task-header">
+                      <h3>{task.title}</h3>
+                      <span className={`status-badge ${isCompleted ? 'status-badge--completed' : 'status-badge--open'}`}>
+                        {isCompleted ? 'Completed' : 'Open'}
+                      </span>
+                    </div>
+                    {task.description ? <p className="task-description">{task.description}</p> : null}
+                    <p className="task-meta">Updated: {new Date(task.updatedAt).toLocaleString()}</p>
+                    <div className="task-actions">
+                      <button type="button" onClick={() => startEdit(task)}>
+                        Edit
+                      </button>
+                      <button type="button" onClick={() => toggleCompleted(task)}>
+                        {isCompleted ? 'Reopen' : 'Mark completed'}
+                      </button>
+                      <button type="button" className="danger" onClick={() => dispatch(deleteTaskAction({ id: task.id }))}>
+                        Delete
+                      </button>
+                    </div>
+                  </>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </section>
     </main>
   );
 }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,9 +1,85 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import App from './App';
 
+function createTask({ title, description } = {}) {
+  if (title !== undefined) {
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: title } });
+  }
+
+  if (description !== undefined) {
+    fireEvent.change(screen.getByLabelText(/description \(optional\)/i), {
+      target: { value: description }
+    });
+  }
+
+  fireEvent.click(screen.getByRole('button', { name: /add task/i }));
+}
+
 describe('App', () => {
-  it('renders scaffold heading', () => {
+  it('shows initial empty state', () => {
     render(<App />);
+
     expect(screen.getByRole('heading', { name: /novel task tracker/i })).toBeInTheDocument();
+    expect(screen.getByText(/no tasks yet/i)).toBeInTheDocument();
+  });
+
+  it('validates create form and adds a task', () => {
+    render(<App />);
+
+    createTask({ title: '   ' });
+    expect(screen.getByRole('alert')).toHaveTextContent(/title is required/i);
+
+    createTask({ title: 'Draft opening scene', description: 'Set the conflict' });
+
+    expect(screen.getByRole('heading', { name: /draft opening scene/i })).toBeInTheDocument();
+    expect(screen.getByText(/set the conflict/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no tasks yet/i)).not.toBeInTheDocument();
+  });
+
+  it('supports edit, complete/reopen, and delete', () => {
+    render(<App />);
+
+    createTask({ title: 'Write chapter plan' });
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    fireEvent.change(screen.getByLabelText(/edit title/i), {
+      target: { value: 'Write detailed chapter plan' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(screen.getByRole('heading', { name: /write detailed chapter plan/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /mark completed/i }));
+    expect(screen.getByText('Completed', { selector: '.status-badge' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /reopen/i }));
+    expect(screen.getByText('Open', { selector: '.status-badge' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    expect(screen.getByText(/no tasks yet/i)).toBeInTheDocument();
+  });
+
+  it('supports baseline search, status filter, and sorting', () => {
+    render(<App />);
+
+    createTask({ title: 'Bravo item', description: 'secondary note' });
+    createTask({ title: 'Alpha item', description: 'primary note' });
+
+    fireEvent.change(screen.getByLabelText(/^search$/i), { target: { value: 'primary' } });
+    expect(screen.getByRole('heading', { name: /alpha item/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /bravo item/i })).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/^search$/i), { target: { value: '' } });
+    fireEvent.click(screen.getAllByRole('button', { name: /mark completed/i })[0]);
+
+    fireEvent.change(screen.getByLabelText(/^status$/i), { target: { value: 'completed' } });
+    expect(screen.getByText('Completed', { selector: '.status-badge' })).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
+
+    fireEvent.change(screen.getByLabelText(/^status$/i), { target: { value: 'all' } });
+    fireEvent.change(screen.getByLabelText(/^sort$/i), { target: { value: 'title-asc' } });
+
+    const titles = screen.getAllByRole('heading', { level: 3 }).map((node) => node.textContent);
+    expect(titles).toEqual(['Alpha item', 'Bravo item']);
   });
 });


### PR DESCRIPTION
## Summary
- implement task CRUD UI on top of the existing tasks reducer/store/action flow from Issue #6
- add task list controls with baseline search, status filter, and sorting
- add visual status differentiation, empty states, and validation/error messaging
- expand integration tests to cover create/list/update/complete/reopen/delete and list controls

## Testing
- npm run lint
- npm run test

Closes #7
