### PR TITLE
feat: add client-side task persistence with versioned localStorage payload

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useReducer, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import './App.css';
 import {
   completeTaskAction,
   createTaskAction,
   deleteTaskAction,
   editTaskAction,
-  loadTasksState,
+  loadTasksStateResult,
   persistTasksState,
   reopenTaskAction,
   tasksReducer
@@ -67,7 +67,9 @@ function selectVisibleTasks(tasks, { query, statusFilter, sortBy }) {
 }
 
 function App() {
-  const [state, dispatch] = useReducer(tasksReducer, undefined, loadTasksState);
+  const loadResult = useMemo(() => loadTasksStateResult(), []);
+  const skipInitialPersistRef = useRef(loadResult.skipInitialPersist);
+  const [state, dispatch] = useReducer(tasksReducer, loadResult.state);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [createError, setCreateError] = useState('');
@@ -80,8 +82,12 @@ function App() {
   const [editDescription, setEditDescription] = useState('');
   const [editError, setEditError] = useState('');
 
-
   useEffect(() => {
+    if (skipInitialPersistRef.current) {
+      skipInitialPersistRef.current = false;
+      return;
+    }
+
     persistTasksState(state);
   }, [state]);
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -137,4 +137,19 @@ describe('App', () => {
     expect(screen.getByRole('heading', { name: /persisted task/i })).toBeInTheDocument();
     expect(screen.getByText(/keep between reloads/i)).toBeInTheDocument();
   });
+
+  it('does not clobber future-version storage on initial mount', () => {
+    const futurePayload = {
+      version: TASKS_STORAGE_VERSION + 1,
+      payload: {
+        tasks: [{ id: 'future-1', title: 'Future task' }]
+      }
+    };
+
+    window.localStorage.setItem(TASKS_STORAGE_KEY, JSON.stringify(futurePayload));
+
+    render(<App />);
+
+    expect(JSON.parse(window.localStorage.getItem(TASKS_STORAGE_KEY))).toEqual(futurePayload);
+  });
 });


### PR DESCRIPTION
## Summary\n- persist task state to localStorage after reducer updates\n- hydrate initial reducer state from localStorage on app boot\n- add a minimal versioned persistence envelope with migration support from legacy payload shapes\n- normalize/sanitize loaded tasks and safely fall back to empty state for invalid/future-version payloads\n- expand unit + integration tests for persistence, migration, and reload behavior\n\n## Verification\n- npm test\n- npm run lint\n- npm run build\n\nCloses #8