### PR TITLE
[Process] Add 2-stage review guideline + PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Summary
+- 
+
+## Linked Issue
+- Closes #
+
+## 2-stage review confirmation
+### Stage 1 — Self-review (author, xhigh reasoning)
+- [ ] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).
+- [ ] I confirmed the implementation satisfies the linked issue scope.
+
+### Stage 2 — Final review (Boe)
+- [ ] Final review requested from **Boe**.
+
+## Validation evidence
+### Lint
+```bash
+# paste command + output
+npm run lint
+```
+
+### Tests
+```bash
+# paste command + output
+npm test
+```
+
+### Build
+```bash
+# paste command + output
+npm run build
+```
+
+## UI changes
+- [ ] N/A (no UI changes)
+- [ ] Screenshots/GIF attached below
+
+## Risks / edge cases
+- 
+
+## Additional notes
+- 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Thanks for contributing to **novel-task-tracker**.
+
+## Branch + PR flow
+
+1. Branch from `main` with `feat/issue-<number>-<summary>`.
+2. Keep commits scoped to one issue.
+3. Open a PR that links the issue (example: `Closes #14`).
+4. Follow the **2-stage review process** below before requesting merge.
+
+## 2-stage review process (required)
+
+### Stage 1 — Self-review (author, xhigh reasoning)
+Before assigning final reviewer, the PR author performs a deep self-review and confirms:
+
+- Requirement coverage is complete for the linked issue.
+- Logic/edge cases were checked with **xhigh reasoning** (assumptions validated, failure paths reviewed).
+- Tests/lint/build were run and outputs are pasted in the PR.
+- If UI changed, screenshots/GIFs are attached.
+- Risks, regressions, and rollback considerations are documented.
+
+### Stage 2 — Final review (Boe)
+After Stage 1 is complete, request final review from **Boe**.
+
+- Boe verifies requirement fit, code quality, and release safety.
+- PR is merged only after Boe approval and green CI.
+
+## PR checklist (copy into PR or use default template)
+
+- [ ] Linked issue(s) included (`Closes #...`)
+- [ ] Stage 1 self-review complete (xhigh reasoning applied)
+- [ ] `npm run lint` result attached
+- [ ] `npm test` result attached
+- [ ] `npm run build` result attached
+- [ ] UI change evidence attached (screenshots/GIF), or marked N/A
+- [ ] Risks/edge cases documented
+- [ ] Stage 2 final review requested from Boe

--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ Gate must pass before merge:
 1. Create a branch from `main` using `feat/issue-<number>-<summary>`.
 2. Keep commits small and scoped to one issue.
 3. Open a PR that references the issue (example: `Closes #5`).
-4. Request review before merge.
+4. Follow the required 2-stage review process in [`CONTRIBUTING.md`](./CONTRIBUTING.md):
+   - Stage 1 self-review by author (xhigh reasoning)
+   - Stage 2 final review by Boe
+5. Use the PR checklist template and attach lint/test/build evidence.
 
 ## Core task domain model (Issue #6)
 Task shape in state:


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with required 2-stage review process
  - Stage 1: author self-review with xhigh reasoning
  - Stage 2: final review by Boe
- add default PR template at `.github/pull_request_template.md`
- update README Branch/PR workflow to reference the new process + checklist

## Linked Issue
Closes #14

## 2-stage review confirmation
### Stage 1 — Self-review (author, xhigh reasoning)
- [x] Completed self-review with xhigh reasoning for requirement and edge-case coverage.
- [x] Confirmed implementation matches issue scope.

### Stage 2 — Final review (Boe)
- [x] Final review requested from **Boe** in this PR.

## Validation evidence
### Lint
```bash
npm run lint
> novel-task-tracker@0.1.0 lint
> eslint . --ext js,jsx --max-warnings 0
```

### Tests
```bash
npm test -- --run
RUN  v2.1.9 /Users/syong/.openclaw/workspace-orchestrator/novel-task-tracker
✓ src/domain/tefq.test.js (4)
✓ src/state/tasks.test.js (13)
✓ src/App.test.jsx (7)
Test Files  3 passed (3)
Tests       24 passed (24)
```

### Build
```bash
npm run build
vite v5.4.21 building for production...
✓ built in 349ms
```

## UI changes
- [x] N/A (docs/process only)

## Risks / edge cases
- Low risk: docs-only change.
- Mitigation: added process guidance in both CONTRIBUTING and PR template to reduce checklist drift.
