### PR TITLE
feat: responsive UX for mobile and desktop web (issue #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,6 @@ Tie-breakers:
 - Completed tasks are excluded.
 - Tasks missing duration/energy are excluded from TEFQ ranking.
 - When context filter has no direct matches, closest alternatives appear in a fallback block with guidance to relax context.
+
+## Responsive UX QA checklist (Issue #9)
+Use the quick manual checklist at [`docs/qa/responsive-qa-checklist.md`](./docs/qa/responsive-qa-checklist.md) when validating mobile/desktop behavior before merge.

--- a/docs/qa/responsive-qa-checklist.md
+++ b/docs/qa/responsive-qa-checklist.md
@@ -1,0 +1,30 @@
+# Responsive UX QA Checklist (Issue #9)
+
+Quick manual checks for mobile + desktop layouts.
+
+## Test Setup
+- App running via `npm run dev`.
+- Browser devtools responsive mode available.
+
+## Viewports to Verify
+- Mobile: **320×568** (iPhone SE-ish)
+- Mobile large: **390×844**
+- Tablet/Desktop transition: **768×1024**
+- Desktop: **1280×800**
+
+## Checklist
+- [ ] Page content is fully usable at each viewport size (no blocked sections).
+- [ ] “Now queue”, “Add task”, and “Tasks” sections remain readable and navigable.
+- [ ] Core actions are accessible on small widths:
+  - [ ] Add task
+  - [ ] Edit task
+  - [ ] Mark completed / Reopen
+  - [ ] Delete
+  - [ ] Search / filter / sort
+- [ ] Task action buttons remain clickable without horizontal panning.
+- [ ] No critical horizontal overflow in task cards, metadata, status chips, or controls.
+- [ ] Long titles/descriptions wrap without layout breakage.
+- [ ] Desktop layout uses available width effectively (two-column top sections + full-width task list).
+
+## Notes
+Capture any viewport-specific issues with screenshot + reproduction steps.

--- a/src/App.css
+++ b/src/App.css
@@ -1,24 +1,26 @@
 .app {
-  max-width: 900px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: 1.5rem;
+  padding: clamp(0.9rem, 2vw, 1.5rem);
   display: grid;
   gap: 1rem;
 }
 
 .app h1 {
   margin: 0;
+  line-height: 1.2;
 }
 
 .panel {
   background: #fff;
   border: 1px solid #e2e8f0;
   border-radius: 12px;
-  padding: 1rem;
+  padding: clamp(0.8rem, 1.4vw, 1rem);
 }
 
 .panel h2 {
   margin-top: 0;
+  line-height: 1.25;
 }
 
 .panel-copy {
@@ -37,7 +39,7 @@
 .controls {
   display: grid;
   gap: 0.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(170px, 100%), 1fr));
   margin-bottom: 1rem;
 }
 
@@ -60,6 +62,10 @@ select {
   padding: 0.55rem 0.7rem;
   border: 1px solid #cbd5e1;
   border-radius: 8px;
+}
+
+textarea {
+  resize: vertical;
 }
 
 button {
@@ -96,6 +102,14 @@ button.danger {
   background: #f8fafc;
 }
 
+.task-item,
+.task-header h3,
+.task-description,
+.task-meta,
+.reason-chip {
+  overflow-wrap: anywhere;
+}
+
 .task-item--completed {
   border-color: #86efac;
   background: #f0fdf4;
@@ -108,7 +122,7 @@ button.danger {
 
 .task-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 0.5rem;
 }
@@ -122,6 +136,7 @@ button.danger {
   font-weight: 600;
   border-radius: 999px;
   padding: 0.15rem 0.55rem;
+  white-space: nowrap;
 }
 
 .status-badge--open {
@@ -147,6 +162,16 @@ button.danger {
 
 .task-meta--stacked {
   margin-top: 0.35rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.task-meta--stacked span {
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  padding: 0.1rem 0.45rem;
 }
 
 .task-actions {
@@ -181,4 +206,36 @@ button.danger {
   margin: 0;
   color: #b91c1c;
   font-size: 0.875rem;
+}
+
+@media (min-width: 960px) {
+  .app {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .app h1,
+  .panel--tasks {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .controls {
+    grid-template-columns: 1fr;
+    margin-bottom: 0.75rem;
+  }
+
+  .task-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .task-actions button {
+    width: 100%;
+  }
+
+  .status-badge {
+    font-size: 0.72rem;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -251,7 +251,7 @@ function App() {
     <main className="app">
       <h1>Novel Task Tracker</h1>
 
-      <section className="panel" aria-label="Now queue">
+      <section className="panel panel--now" aria-label="Now queue">
         <h2>Now queue (TEFQ)</h2>
         <p className="panel-copy">Pick your current constraints to get deterministic “do this now” suggestions.</p>
 
@@ -353,7 +353,7 @@ function App() {
         ) : null}
       </section>
 
-      <section className="panel" aria-label="Create task">
+      <section className="panel panel--create" aria-label="Create task">
         <h2>Add task</h2>
         <form onSubmit={handleCreate} className="task-form">
           <label htmlFor="task-title">Title</label>
@@ -445,7 +445,7 @@ function App() {
         </form>
       </section>
 
-      <section className="panel" aria-label="Filter and sort tasks">
+      <section className="panel panel--tasks" aria-label="Filter and sort tasks">
         <h2>Tasks</h2>
         <div className="controls">
           <label htmlFor="search-tasks">Search</label>
@@ -606,9 +606,11 @@ function App() {
                     {task.description ? <p className="task-description">{task.description}</p> : null}
                     <p className="task-meta">Updated: {new Date(task.updatedAt).toLocaleString()}</p>
                     <p className="task-meta task-meta--stacked">
-                      Due: {task.dueDate ?? 'Not set'} · Priority: {task.priority === TASK_PRIORITY.HIGH ? 'High' : 'Normal'} ·
-                      Duration: {task.estimatedDurationMin ? `${task.estimatedDurationMin} min` : 'Not set'} · Energy:{' '}
-                      {formatEnergy(task.energy)} · Context: {formatContext(task.context)}
+                      <span>Due: {task.dueDate ?? 'Not set'}</span>
+                      <span>Priority: {task.priority === TASK_PRIORITY.HIGH ? 'High' : 'Normal'}</span>
+                      <span>Duration: {task.estimatedDurationMin ? `${task.estimatedDurationMin} min` : 'Not set'}</span>
+                      <span>Energy: {formatEnergy(task.energy)}</span>
+                      <span>Context: {formatContext(task.context)}</span>
                     </p>
                     <div className="task-actions">
                       <button type="button" onClick={() => startEdit(task)}>


### PR DESCRIPTION
## Summary
- implement responsive layout tuning for mobile + desktop breakpoints
- improve small-screen usability by stacking controls/actions and preventing content overflow
- refine task metadata rendering into wrapped chips to avoid critical horizontal overflow
- add manual responsive QA checklist doc

Closes #9

## What changed
- `src/App.css`
  - desktop breakpoint (`>=960px`): two-column layout for top panels, full-width tasks panel
  - mobile breakpoint (`<=640px`): single-column controls and full-width action buttons
  - hardened overflow handling (`overflow-wrap:anywhere`) for long task/title/meta/chip content
  - improved control grid behavior using `minmax(min(170px, 100%), 1fr)`
  - wrapped metadata chip row for due/priority/duration/energy/context
- `src/App.jsx`
  - add semantic panel modifiers (`panel--now`, `panel--create`, `panel--tasks`) for responsive placement
  - split long metadata line into wrapped spans for reliable small-width rendering
- `docs/qa/responsive-qa-checklist.md`
  - quick manual QA checklist for 320/390/768/1280 viewport validation
- `README.md`
  - add link to responsive QA checklist doc

## Verification
- `npm run lint`
- `npm test`
- `npm run build`

All passed locally.

## Manual QA checklist location
- `docs/qa/responsive-qa-checklist.md`
