### PR TITLE
feat: add GitHub Pages deployment workflow (issue #22)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,56 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Baseline React scaffold for the Novel Task Tracker project.
 
+## Live demo
+GitHub Pages: https://clay-agency.github.io/novel-task-tracker/
+
 ## Prerequisites
 - Node.js 18+
 - npm 9+

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/novel-task-tracker/',
   plugins: [react()],
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
- add official GitHub Pages deployment workflow for Vite build artifacts (`dist`)
- set Vite `base` to `/novel-task-tracker/` for Pages routing
- document live site URL in README

Closes #22

## Verification
- npm run lint
- npm test -- --run
- npm run build
