### PR TITLE
docs: add pilot FAQ + troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,5 +135,6 @@ Use the pilot gate checklist and browser/device validation plan at [`docs/qa/pil
 ## Pilot onboarding packet + demo script (Issue #30)
 Use these docs for pilot participant onboarding, live walkthroughs, and structured feedback capture:
 - [`docs/pilot/onboarding.md`](./docs/pilot/onboarding.md)
+- [`docs/pilot/faq-troubleshooting.md`](./docs/pilot/faq-troubleshooting.md)
 - [`docs/pilot/demo-script.md`](./docs/pilot/demo-script.md)
 - [`docs/pilot/feedback-questions.md`](./docs/pilot/feedback-questions.md)

--- a/docs/pilot/faq-troubleshooting.md
+++ b/docs/pilot/faq-troubleshooting.md
@@ -1,0 +1,90 @@
+# Pilot FAQ + Troubleshooting
+
+This guide helps pilot users quickly resolve common setup and usage issues.
+
+## Quick FAQ
+
+### Where is my data stored?
+- Task data is stored in your browser `localStorage` under the key `novel-task-tracker/tasks`.
+- Data is local to the **same browser + profile + device**.
+- This pilot does **not** send task data to a backend service.
+
+### Can I safely reset my data?
+Yes. Use one of these options:
+
+1. **In-app reset by deleting tasks**
+   - Reopen the app and delete tasks one by one from the task list.
+   - Best when you only want to remove some tasks.
+
+2. **Browser storage reset (full local reset for this app)**
+   - Open browser DevTools → Application/Storage → Local Storage.
+   - Remove `novel-task-tracker/tasks`.
+   - Refresh the app.
+
+> Tip: Storage reset is irreversible for this pilot build (no account backup/sync).
+
+### What happens in Private/Incognito mode?
+- The app may work for the current session, but data usually clears when the private window is closed.
+- Some browsers may block or restrict storage in private mode.
+- If storage is blocked, the app should still run, but data may not persist after refresh/reopen.
+
+### What if my browser blocks local storage?
+- Check browser privacy/security settings and site permissions.
+- Allow site data/local storage for `clay-agency.github.io`.
+- Disable strict anti-tracking/storage blocking for this site (or test in another browser profile).
+- If you cannot enable storage, you can still run a short-session test, but persistence checks will be unreliable.
+
+### How do search/filter/sort work?
+- **Search** matches task title and description text.
+- **Status filter** narrows to open/completed/all tasks.
+- **Sort** reorders task list (for example, by recently updated, created time, or title).
+- If no items appear, clear search/filter selections first.
+
+### Why is my task not showing in TEFQ (Now Queue)?
+A task must be **open** and include both:
+- `Estimated duration (min)`
+- `Energy required` (low/medium/high)
+
+Also check:
+- Current time/energy inputs in the Now Queue panel.
+- Optional context filter (it can limit primary matches; fallback suggestions may appear separately).
+
+## Troubleshooting quick checks
+
+### "My tasks disappeared"
+1. Confirm you are using the same browser/profile/device.
+2. Check whether you are in Private/Incognito mode.
+3. Verify browser/site settings are not clearing storage on close.
+4. If data was cleared, recreate sample tasks for pilot continuation.
+
+### "Changes do not persist after refresh"
+1. Open browser console and look for storage/privacy errors.
+2. Confirm local storage is allowed for the site.
+3. Retry in a normal (non-private) window.
+4. Retry with extensions disabled (privacy/ad-block extensions can interfere).
+
+### "Now Queue is empty"
+1. Ensure there are open tasks.
+2. Add duration + energy on tasks.
+3. Relax context filter or adjust available minutes/current energy inputs.
+
+### "No tasks match search/filter"
+1. Clear search text.
+2. Set Status filter back to `All`.
+3. Reset Sort if needed to re-check ordering.
+
+## Reporting bugs or pilot issues
+When reporting an issue, include:
+- browser + version,
+- OS/device,
+- exact steps to reproduce,
+- expected vs actual result,
+- screenshots/video if available.
+
+Use repository issue templates:
+- Bug report: [`../../.github/ISSUE_TEMPLATE/bug-report.md`](../../.github/ISSUE_TEMPLATE/bug-report.md)
+- QA finding: [`../../.github/ISSUE_TEMPLATE/qa-finding.md`](../../.github/ISSUE_TEMPLATE/qa-finding.md)
+- Feature request: [`../../.github/ISSUE_TEMPLATE/feature-request.md`](../../.github/ISSUE_TEMPLATE/feature-request.md)
+
+Or open the template chooser directly:
+- https://github.com/Clay-Agency/novel-task-tracker/issues/new/choose

--- a/docs/pilot/onboarding.md
+++ b/docs/pilot/onboarding.md
@@ -9,6 +9,9 @@ This onboarding guide is for pilot participants and facilitators to align on:
 - how task data is stored,
 - and current pilot limitations.
 
+## Related pilot docs
+- FAQ + troubleshooting: [`docs/pilot/faq-troubleshooting.md`](./faq-troubleshooting.md)
+
 ## Pilot app link
 - Live app: https://clay-agency.github.io/novel-task-tracker/
 


### PR DESCRIPTION
## Summary
- add `docs/pilot/faq-troubleshooting.md` for pilot users
- cover localStorage storage behavior, safe reset, private mode/storage-blocked scenarios
- add common UX FAQ (search/filter/sort + TEFQ eligibility)
- add bug reporting guidance with issue template links
- link FAQ from README and onboarding doc

Closes #34
