### PR TITLE
feat: accessibility baseline pass for core UI + TEFQ (closes #35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ Use the quick manual checklist at [`docs/qa/responsive-qa-checklist.md`](./docs/
 ## Pilot readiness + cross-browser QA plan (Issue #27)
 Use the pilot gate checklist and browser/device validation plan at [`docs/qa/pilot-readiness-cross-browser-plan.md`](./docs/qa/pilot-readiness-cross-browser-plan.md).
 
+## Accessibility baseline manual check (Issue #35)
+Use the quick keyboard/ARIA smoke pass at [`docs/qa/accessibility-baseline-check.md`](./docs/qa/accessibility-baseline-check.md) before merging UI changes.
+
 ## Pilot onboarding packet + demo script (Issue #30)
 Use these docs for pilot participant onboarding, live walkthroughs, and structured feedback capture:
 - [`docs/pilot/onboarding.md`](./docs/pilot/onboarding.md)

--- a/docs/qa/accessibility-baseline-check.md
+++ b/docs/qa/accessibility-baseline-check.md
@@ -1,0 +1,22 @@
+# Accessibility Baseline Manual Check (Issue #35)
+
+Lightweight pass for pilot readiness (not a full WCAG audit).
+
+## Quick check steps
+1. Run app locally (`npm run dev`) and use keyboard only (no mouse).
+2. Confirm core flows are reachable and usable:
+   - Add task
+   - Edit task (including `Esc` to cancel)
+   - Mark completed / Reopen
+   - Delete
+   - Search / status filter / sort
+   - TEFQ controls (time, energy, context)
+3. Confirm visible focus ring appears on inputs, selects, and buttons.
+4. Confirm screen reader semantics are present:
+   - Form controls have labels
+   - Task action buttons include task-specific names
+   - Task count/status updates are announced via live regions
+
+## Record findings
+- Capture browser + OS + assistive tech used.
+- Log any blocker as GitHub issue with repro steps.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -74,7 +74,7 @@ async function createTask(
     await page.locator('#task-context').selectOption(context);
   }
 
-  await page.getByRole('button', { name: 'Add task' }).click();
+  await page.getByRole('button', { name: /add task/i }).click();
 }
 
 test('supports core task lifecycle and persistence across reload', async ({ page }) => {
@@ -88,13 +88,13 @@ test('supports core task lifecycle and persistence across reload', async ({ page
   await page.reload();
   await expect(taskList.getByRole('heading', { name: 'Persistent smoke task' })).toBeVisible();
 
-  await page.getByRole('button', { name: 'Mark completed' }).click();
+  await page.getByRole('button', { name: /mark completed/i }).click();
   await expect(taskList.getByText('Completed')).toBeVisible();
 
-  await page.getByRole('button', { name: 'Reopen' }).click();
+  await page.getByRole('button', { name: /reopen/i }).click();
   await expect(taskList.getByText('Open')).toBeVisible();
 
-  await page.getByRole('button', { name: 'Delete' }).click();
+  await page.getByRole('button', { name: /delete/i }).click();
   await expect(taskList.getByRole('heading', { name: 'Persistent smoke task' })).toHaveCount(0);
 });
 
@@ -113,7 +113,7 @@ test('supports search, status filtering, and title sorting', async ({ page }) =>
   await expect(taskList.getByRole('heading', { name: 'Alpha sprint notes' })).toBeVisible();
   await expect(taskList.getByRole('heading', { name: 'Zeta draft notes' })).toHaveCount(0);
 
-  await page.getByRole('button', { name: 'Mark completed' }).click();
+  await page.getByRole('button', { name: /mark completed/i }).click();
   await page.locator('#status-filter').selectOption('completed');
   await expect(taskList.getByRole('heading', { name: 'Alpha sprint notes' })).toBeVisible();
 });

--- a/src/App.css
+++ b/src/App.css
@@ -36,6 +36,13 @@
   gap: 0.5rem;
 }
 
+.fieldset-reset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-inline-size: 0;
+}
+
 .controls {
   display: grid;
   gap: 0.5rem;
@@ -85,6 +92,14 @@ button.secondary {
 button.danger {
   background: #7f1d1d;
   border-color: #7f1d1d;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 2px;
 }
 
 .task-list {
@@ -206,6 +221,18 @@ button.danger {
   margin: 0;
   color: #b91c1c;
   font-size: 0.875rem;
+}
+
+.sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 @media (min-width: 960px) {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -158,7 +158,7 @@ describe('App core UI flows', () => {
     fireEvent.change(screen.getByLabelText(/edit energy required/i), {
       target: { value: 'high' }
     });
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
 
     const taskList = screen.getByRole('list', { name: /task list/i });
     expect(within(taskList).getByRole('heading', { name: /write detailed chapter plan/i })).toBeInTheDocument();
@@ -173,6 +173,24 @@ describe('App core UI flows', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /delete/i }));
     expect(screen.getByText(/no tasks yet/i)).toBeInTheDocument();
+  });
+
+
+  it('supports keyboard escape to cancel edit mode and exposes task-specific action labels', () => {
+    render(<App />);
+
+    createTask({ title: 'Keyboard task' });
+
+    fireEvent.click(screen.getByRole('button', { name: /edit keyboard task/i }));
+    const editTitleInput = screen.getByLabelText(/edit title/i);
+    fireEvent.change(editTitleInput, { target: { value: 'Changed title' } });
+
+    fireEvent.keyDown(editTitleInput, { key: 'Escape' });
+
+    expect(screen.queryByLabelText(/edit title/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /keyboard task/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /mark completed keyboard task/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete keyboard task/i })).toBeInTheDocument();
   });
 
   it('supports search/filter/sort controls', () => {


### PR DESCRIPTION
## Summary
- add lightweight keyboard and ARIA improvements for core UI and TEFQ controls
- improve screen-reader semantics with grouped fieldsets, task-specific action labels, and live status announcements
- add visible focus-visible styling and keyboard Escape support to cancel task edit mode
- add a short manual accessibility smoke-check doc and link it from README
- update tests to cover keyboard/a11y behavior and adjust e2e role name matchers

Closes #35

## Validation
- npm run lint
- npm run test
- npm run build
- npm run e2e
