### PR TITLE
docs(pilot): add feedback synthesis template and weekly report format

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ Use the pilot gate checklist and browser/device validation plan at [`docs/qa/pil
 ## Accessibility baseline manual check (Issue #35)
 Use the quick keyboard/ARIA smoke pass at [`docs/qa/accessibility-baseline-check.md`](./docs/qa/accessibility-baseline-check.md) before merging UI changes.
 
-## Pilot onboarding packet + demo script (Issue #30)
-Use these docs for pilot participant onboarding, live walkthroughs, and structured feedback capture:
+## Pilot onboarding + feedback operations (Issues #30, #41)
+Use these docs for pilot participant onboarding, live walkthroughs, structured feedback capture, and weekly synthesis/reporting:
 - [`docs/pilot/onboarding.md`](./docs/pilot/onboarding.md)
 - [`docs/pilot/faq-troubleshooting.md`](./docs/pilot/faq-troubleshooting.md)
 - [`docs/pilot/demo-script.md`](./docs/pilot/demo-script.md)
 - [`docs/pilot/feedback-questions.md`](./docs/pilot/feedback-questions.md)
+- [`docs/pilot/feedback-synthesis-template.md`](./docs/pilot/feedback-synthesis-template.md)
+- [`docs/pilot/weekly-report-format.md`](./docs/pilot/weekly-report-format.md)

--- a/docs/pilot/feedback-synthesis-template.md
+++ b/docs/pilot/feedback-synthesis-template.md
@@ -1,0 +1,90 @@
+# Pilot Feedback Synthesis Template
+
+Use this template to turn raw pilot sessions into actionable product and engineering work.
+
+## How to use
+1. Create one synthesis entry per participant/session.
+2. Capture direct evidence (quotes, screen recording timestamps, repro notes).
+3. Convert findings into GitHub issues and link them.
+4. Roll high-signal findings into the weekly report format.
+
+---
+
+## Session metadata
+- Facilitator:
+- Date:
+- Participant:
+- Role / team:
+- Experience level with task tools:
+- Device + browser:
+- Session type: (live demo / self-serve / async notes)
+- Duration:
+
+## 1) Feedback intake
+- **What they tried**
+  - Example: task create/edit/delete, complete/reopen, TEFQ queue tuning, search/filter/sort
+- **Context**
+  - Real workflow or synthetic test?
+  - Approx. task volume used in session:
+  - Time/energy settings tested:
+- **Outcome summary (2–3 bullets)**
+  -
+  -
+
+## 2) Observations + quotes
+| Area | Observation | Evidence (quote or timestamp) | Impact |
+| --- | --- | --- | --- |
+| Onboarding |  |  |  |
+| Core task flow |  |  |  |
+| TEFQ usefulness |  |  |  |
+| Reliability/performance |  |  |  |
+| Accessibility/responsive |  |  |  |
+
+## 3) Issues found (bugs)
+| ID | Finding | Severity (S1-S4) | Priority (P0-P2) | Owner | GitHub issue |
+| --- | --- | --- | --- | --- | --- |
+| B-01 |  |  |  |  | [#](https://github.com/Clay-Agency/novel-task-tracker/issues/) |
+| B-02 |  |  |  |  | [#](https://github.com/Clay-Agency/novel-task-tracker/issues/) |
+
+## 4) Feature requests
+| ID | Request | Why it matters | Priority (P0-P2) | Owner | GitHub issue |
+| --- | --- | --- | --- | --- | --- |
+| F-01 |  |  |  |  | [#](https://github.com/Clay-Agency/novel-task-tracker/issues/) |
+| F-02 |  |  |  |  | [#](https://github.com/Clay-Agency/novel-task-tracker/issues/) |
+
+## 5) Next-week plan
+- **Top 3 goals**
+  1.
+  2.
+  3.
+- **Planned issue set**
+  - Must-fix before broader pilot:
+  - Should-fix for confidence:
+  - Nice-to-have experiments:
+- **Risks / dependencies**
+  -
+- **Decision needed from stakeholders**
+  -
+
+---
+
+## Prioritization + severity rubric
+
+### Priority (implementation order)
+- **P0 — Blocker / immediate**: prevents pilot progress or invalidates data quality. Fix now.
+- **P1 — Important / near-term**: materially harms usability or confidence; fix in next cycle.
+- **P2 — Valuable / can wait**: meaningful improvement but not required for pilot continuity.
+
+### Severity (user impact)
+- **S1 — Critical**: data loss, app unusable, security/privacy break.
+- **S2 — High**: core workflow broken or highly unreliable for many users.
+- **S3 — Medium**: partial workflow friction; workaround exists.
+- **S4 — Low**: minor UX polish issue or edge-case annoyance.
+
+### Quick triage rule of thumb
+- Start with **Severity** (impact), then assign **Priority** (when we will do it).
+- Typical mapping (adjust with judgment):
+  - S1 → P0
+  - S2 → P0/P1
+  - S3 → P1/P2
+  - S4 → P2

--- a/docs/pilot/onboarding.md
+++ b/docs/pilot/onboarding.md
@@ -11,6 +11,9 @@ This onboarding guide is for pilot participants and facilitators to align on:
 
 ## Related pilot docs
 - FAQ + troubleshooting: [`docs/pilot/faq-troubleshooting.md`](./faq-troubleshooting.md)
+- Feedback interview guide: [`docs/pilot/feedback-questions.md`](./feedback-questions.md)
+- Feedback synthesis template: [`docs/pilot/feedback-synthesis-template.md`](./feedback-synthesis-template.md)
+- Weekly report format: [`docs/pilot/weekly-report-format.md`](./weekly-report-format.md)
 
 ## Pilot app link
 - Live app: https://clay-agency.github.io/novel-task-tracker/

--- a/docs/pilot/weekly-report-format.md
+++ b/docs/pilot/weekly-report-format.md
@@ -1,0 +1,71 @@
+# Pilot Weekly Report Format
+
+Use this format for weekly pilot updates to align product, design, and engineering.
+
+## Week header
+- Week of:
+- Report owner:
+- Pilot participants active this week:
+- Sessions completed:
+- Linked synthesis docs:
+  - 
+
+## 1) Executive summary (5 bullets max)
+- Pilot health (Green / Yellow / Red):
+- Biggest win:
+- Biggest risk:
+- Most important user signal:
+- Ask/decision needed this week:
+
+## 2) What we learned
+### Adoption + usability signals
+- 
+
+### TEFQ usefulness signals
+- 
+
+### Reliability / quality signals
+- 
+
+## 3) Findings converted to backlog
+### Bugs opened/updated this week
+| Issue | Title | Sev | Pri | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| # |  | S | P |  |  |
+
+### Feature requests opened/updated this week
+| Issue | Title | Pri | Status | Notes |
+| --- | --- | --- | --- | --- |
+| # |  | P |  |  |
+
+## 4) Prioritization snapshot
+- **P0 this week**:
+- **P1 queued next**:
+- **P2 parked**:
+
+## 5) Plan for next week
+- Delivery goals:
+  1.
+  2.
+  3.
+- Research goals:
+  1.
+  2.
+- Success criteria for next report:
+  -
+
+## 6) Risks, dependencies, and decisions
+- Risk:
+- Dependency:
+- Decision required (owner + due date):
+
+---
+
+## Optional KPI tracker
+| Metric | This week | Last week | Trend |
+| --- | --- | --- | --- |
+| Session completion rate |  |  |  |
+| Task creation success |  |  |  |
+| TEFQ perceived relevance (Often %) |  |  |  |
+| Bug count (S1/S2 only) |  |  |  |
+| Would continue using (Yes %) |  |  |  |


### PR DESCRIPTION
## Summary
- Add `docs/pilot/feedback-synthesis-template.md` with:
  - feedback intake section (participant, context, what they tried)
  - observations + quote capture table
  - bug/issues table with GitHub issue links
  - feature request table with GitHub issue links
  - next-week plan section
  - prioritization + severity rubric (P0/P1/P2 and S1-S4)
- Add `docs/pilot/weekly-report-format.md` for weekly pilot synthesis/reporting
- Link new pilot docs from:
  - `docs/pilot/onboarding.md`
  - `README.md`

## Linked Issue
- Closes #41

## 2-stage review confirmation
### Stage 1 — Self-review (author, xhigh reasoning)
- [x] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).
- [x] I confirmed the implementation satisfies the linked issue scope.

### Stage 2 — Final review (Boe)
- [x] Final review requested from **Boe**.

## Validation evidence
### Lint
```bash
npm run lint
# eslint . --ext js,jsx,ts,tsx --max-warnings 0
```

### Tests
```bash
npm test
# Test Files  3 passed (3)
# Tests      25 passed (25)
```

### Build
```bash
npm run build
# vite build
# ✓ built in 362ms
```

## UI changes
- [x] N/A (no UI changes)
- [ ] Screenshots/GIF attached below

## Risks / edge cases
- Docs-only change; no runtime behavior impact.

## Additional notes
- Weekly report format was added to match the issue title scope ("+ weekly report format") in addition to the synthesis template acceptance criteria.
