### PR TITLE
feat: liquid glass design refresh

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,25 +8,51 @@
 
 .app h1 {
   margin: 0;
-  line-height: 1.2;
+  line-height: 1.16;
+  color: var(--text-primary);
+  letter-spacing: -0.015em;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
 .panel {
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(145deg, var(--glass-strong), var(--glass-surface));
+  border: 1px solid var(--glass-border);
+  border-radius: 18px;
   padding: clamp(0.8rem, 1.4vw, 1rem);
+  box-shadow: var(--glass-shadow);
+  backdrop-filter: blur(22px) saturate(135%);
+  -webkit-backdrop-filter: blur(22px) saturate(135%);
+}
+
+.panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(120deg, var(--glass-highlight), transparent 52%),
+    radial-gradient(circle at 15% 0%, rgba(255, 255, 255, 0.24), transparent 40%);
+  mix-blend-mode: screen;
+}
+
+.panel > * {
+  position: relative;
+  z-index: 1;
 }
 
 .panel h2 {
   margin-top: 0;
+  margin-bottom: 0.4rem;
   line-height: 1.25;
+  color: var(--text-primary);
 }
 
 .panel-copy {
-  margin-top: -0.25rem;
+  margin-top: -0.1rem;
   margin-bottom: 0.75rem;
-  color: #475569;
+  color: var(--text-secondary);
   font-size: 0.95rem;
 }
 
@@ -58,7 +84,7 @@
 
 label {
   font-size: 0.875rem;
-  color: #334155;
+  color: var(--text-secondary);
 }
 
 input,
@@ -73,8 +99,20 @@ textarea,
 select {
   width: 100%;
   padding: 0.55rem 0.7rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
+  color: var(--text-primary);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 88%, transparent);
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--glass-surface) 80%, transparent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.24),
+    0 5px 12px rgba(15, 32, 64, 0.08);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--text-muted);
 }
 
 textarea {
@@ -82,29 +120,46 @@ textarea {
 }
 
 button {
-  border: 1px solid #334155;
-  background: #1e293b;
+  border: 1px solid color-mix(in srgb, var(--accent-strong) 58%, transparent);
+  background: linear-gradient(140deg, var(--accent), var(--accent-strong));
   color: #fff;
-  border-radius: 8px;
+  border-radius: 11px;
   padding: 0.45rem 0.75rem;
   cursor: pointer;
+  box-shadow:
+    0 8px 18px color-mix(in srgb, var(--accent) 30%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.34);
+  transition: transform 140ms ease, box-shadow 160ms ease, filter 180ms ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  filter: saturate(108%);
+}
+
+button:active {
+  transform: translateY(0);
 }
 
 button.secondary {
-  background: #fff;
-  color: #0f172a;
+  background: color-mix(in srgb, var(--glass-surface) 90%, transparent);
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--glass-border) 86%, transparent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.28),
+    var(--glass-shadow-soft);
 }
 
 button.danger {
-  background: #7f1d1d;
-  border-color: #7f1d1d;
+  background: var(--danger-bg);
+  border-color: var(--danger-border);
 }
 
 button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
-  outline: 3px solid #2563eb;
+  outline: 3px solid var(--focus-ring);
   outline-offset: 2px;
 }
 
@@ -117,10 +172,11 @@ textarea:focus-visible {
 }
 
 .task-item {
-  border: 1px solid #cbd5e1;
-  border-radius: 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: 14px;
   padding: 0.75rem;
-  background: #f8fafc;
+  background: color-mix(in srgb, var(--glass-surface) 82%, transparent);
+  box-shadow: var(--glass-shadow-soft);
 }
 
 .task-item,
@@ -132,13 +188,13 @@ textarea:focus-visible {
 }
 
 .task-item--completed {
-  border-color: #86efac;
-  background: #f0fdf4;
+  border-color: var(--success-border);
+  background: linear-gradient(160deg, var(--success-bg), color-mix(in srgb, var(--glass-surface) 78%, transparent));
 }
 
 .task-item--open {
-  border-color: #93c5fd;
-  background: #eff6ff;
+  border-color: var(--open-border);
+  background: linear-gradient(160deg, var(--open-bg), color-mix(in srgb, var(--glass-surface) 82%, transparent));
 }
 
 .task-header {
@@ -150,6 +206,7 @@ textarea:focus-visible {
 
 .task-header h3 {
   margin: 0;
+  color: var(--text-primary);
 }
 
 .status-badge {
@@ -158,26 +215,31 @@ textarea:focus-visible {
   border-radius: 999px;
   padding: 0.15rem 0.55rem;
   white-space: nowrap;
+  border: 1px solid transparent;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }
 
 .status-badge--open {
-  color: #1d4ed8;
-  background: #dbeafe;
+  color: var(--open-fg);
+  background: var(--open-bg);
+  border-color: var(--open-border);
 }
 
 .status-badge--completed {
-  color: #166534;
-  background: #dcfce7;
+  color: var(--success-fg);
+  background: var(--success-bg);
+  border-color: var(--success-border);
 }
 
 .task-description {
   margin: 0.5rem 0;
-  color: #334155;
+  color: var(--text-secondary);
 }
 
 .task-meta {
   margin: 0;
-  color: #475569;
+  color: var(--text-muted);
   font-size: 0.875rem;
 }
 
@@ -189,10 +251,11 @@ textarea:focus-visible {
 }
 
 .task-meta--stacked span {
-  border: 1px solid #cbd5e1;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 88%, transparent);
   border-radius: 999px;
-  background: #fff;
+  background: color-mix(in srgb, var(--glass-surface) 88%, transparent);
   padding: 0.1rem 0.45rem;
+  color: var(--text-secondary);
 }
 
 .task-actions {
@@ -210,9 +273,9 @@ textarea:focus-visible {
 }
 
 .reason-chip {
-  border: 1px solid #93c5fd;
-  background: #f8fbff;
-  color: #1d4ed8;
+  border: 1px solid var(--open-border);
+  background: color-mix(in srgb, var(--open-bg) 84%, transparent);
+  color: var(--open-fg);
   border-radius: 999px;
   font-size: 0.75rem;
   padding: 0.15rem 0.5rem;
@@ -220,13 +283,14 @@ textarea:focus-visible {
 
 .empty-state {
   margin: 0 0 0.75rem;
-  color: #475569;
+  color: var(--text-secondary);
 }
 
 .error {
   margin: 0;
-  color: #b91c1c;
+  color: #d12f2f;
   font-size: 0.875rem;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.22);
 }
 
 .sr-only {
@@ -239,6 +303,20 @@ textarea:focus-visible {
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .panel,
+  .task-item,
+  input,
+  textarea,
+  select,
+  .status-badge,
+  .reason-chip {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: color-mix(in srgb, var(--glass-strong) 95%, white 5%);
+  }
 }
 
 @media (min-width: 960px) {
@@ -270,5 +348,16 @@ textarea:focus-visible {
 
   .status-badge {
     font-size: 0.72rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,90 @@
 :root {
-  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  color-scheme: light dark;
+  font-family: 'SF Pro Text', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color: #111;
-  background-color: #f8fafc;
+
+  --bg-base: #edf3ff;
+  --bg-secondary: #f8fbff;
+  --bg-radial: rgba(255, 255, 255, 0.72);
+  --text-primary: #12213a;
+  --text-secondary: #3d4f6a;
+  --text-muted: #5f7391;
+
+  --glass-surface: rgba(255, 255, 255, 0.62);
+  --glass-strong: rgba(255, 255, 255, 0.82);
+  --glass-border: rgba(255, 255, 255, 0.58);
+  --glass-highlight: rgba(255, 255, 255, 0.52);
+  --glass-shadow: 0 20px 45px rgba(37, 74, 138, 0.18);
+  --glass-shadow-soft: 0 10px 24px rgba(35, 66, 116, 0.14);
+
+  --accent: #2f7dff;
+  --accent-strong: #1d63e4;
+  --focus-ring: rgba(37, 99, 235, 0.8);
+
+  --success-bg: rgba(136, 239, 172, 0.22);
+  --success-fg: #0b6634;
+  --success-border: rgba(75, 176, 123, 0.45);
+
+  --open-bg: rgba(147, 197, 253, 0.2);
+  --open-fg: #1f4dae;
+  --open-border: rgba(91, 146, 219, 0.45);
+
+  --danger-bg: linear-gradient(135deg, rgba(214, 70, 70, 0.96), rgba(164, 31, 31, 0.94));
+  --danger-border: rgba(123, 20, 20, 0.58);
+
+  background: var(--bg-base);
+  color: var(--text-primary);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-base: #081220;
+    --bg-secondary: #0c1b2c;
+    --bg-radial: rgba(56, 91, 145, 0.28);
+    --text-primary: #e3ecff;
+    --text-secondary: #bfd0eb;
+    --text-muted: #99afcf;
+
+    --glass-surface: rgba(16, 32, 50, 0.58);
+    --glass-strong: rgba(20, 38, 58, 0.78);
+    --glass-border: rgba(144, 181, 234, 0.24);
+    --glass-highlight: rgba(194, 220, 255, 0.16);
+    --glass-shadow: 0 24px 52px rgba(1, 7, 20, 0.52);
+    --glass-shadow-soft: 0 14px 28px rgba(4, 10, 20, 0.44);
+
+    --accent: #79b0ff;
+    --accent-strong: #5e98f0;
+    --focus-ring: rgba(121, 176, 255, 0.8);
+
+    --success-bg: rgba(92, 184, 130, 0.24);
+    --success-fg: #bcf3d2;
+    --success-border: rgba(129, 234, 175, 0.38);
+
+    --open-bg: rgba(67, 120, 188, 0.32);
+    --open-fg: #d5e7ff;
+    --open-border: rgba(126, 171, 237, 0.4);
+
+    --danger-bg: linear-gradient(135deg, rgba(199, 63, 63, 0.95), rgba(146, 24, 24, 0.9));
+    --danger-border: rgba(230, 112, 112, 0.5);
+  }
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
 body {
   margin: 0;
+  color: var(--text-primary);
+  background:
+    radial-gradient(circle at 15% -10%, var(--bg-radial), transparent 58%),
+    radial-gradient(circle at 90% 0%, rgba(109, 171, 255, 0.26), transparent 44%),
+    linear-gradient(165deg, var(--bg-base), var(--bg-secondary));
 }


### PR DESCRIPTION
## Summary
- apply an Apple-style "liquid glass" refresh using pure CSS tokens and backdrop-filter panels
- keep the existing app structure/layout while updating panels, forms, buttons, status badges, and chips
- add light + dark visual themes via prefers-color-scheme, with focus/accessibility and reduced-motion support

## Details
- introduced centralized design tokens in `src/index.css` (glass surfaces, borders, shadows, accents, text colors)
- added layered gradient background + frosted panel highlights for vibrancy/depth
- updated input/select/textarea/button states to glassmorphism styling without changing functionality
- refreshed task cards, metadata chips, reason chips, and status badges to match the new glass system
- preserved desktop alignment/grid behavior (`.app` and panel column rules unchanged)
- added fallback styles for environments without backdrop-filter support

## Verification
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build`

## Screenshots
Captured locally for before/after desktop + mobile:
- `reports/screenshots/issue-44-before-desktop.png`
- `reports/screenshots/issue-44-after-desktop.png`
- `reports/screenshots/issue-44-before-mobile.png`
- `reports/screenshots/issue-44-after-mobile.png`

Closes #44
