### PR TITLE
docs(pilot): add kickoff checklist and facilitator guide

### DIFF
--- a/docs/pilot/facilitator-guide.md
+++ b/docs/pilot/facilitator-guide.md
@@ -1,0 +1,95 @@
+# Pilot Facilitator Guide
+
+This guide helps facilitators run consistent pilot sessions, collect high-signal evidence, and translate feedback into actionable issues.
+
+## Session objective
+- Understand whether core task workflows are fast and intuitive.
+- Validate whether TEFQ "Now Queue" recommendations are understandable and useful.
+- Capture concrete friction points with evidence strong enough to prioritize work.
+
+## Recommended roles
+- **Facilitator (required):** runs session, asks questions, controls pacing.
+- **Note-taker (recommended):** captures quotes, timestamps, and issue candidates.
+
+## Before session
+1. Run the preflight in [`docs/pilot/kickoff-checklist.md`](./kickoff-checklist.md).
+2. Review script and prompts:
+   - Demo flow: [`docs/pilot/demo-script.md`](./demo-script.md)
+   - Interview prompts: [`docs/pilot/feedback-questions.md`](./feedback-questions.md)
+3. Prepare synthesis template for immediate post-session consolidation:
+   - [`docs/pilot/feedback-synthesis-template.md`](./feedback-synthesis-template.md)
+
+## Suggested run-of-show (30–40 minutes)
+
+### 1) Intro and framing (3–5 min)
+- Explain this is a pilot prototype and candid feedback is expected.
+- Set expectation: you may interrupt to ask clarifying questions.
+- Confirm whether participant is using real workflow examples or synthetic tasks.
+
+### 2) Guided walkthrough (8–12 min)
+Use [`demo-script.md`](./demo-script.md) as the baseline sequence:
+- capture/edit/complete/reopen/delete,
+- search/filter/sort,
+- TEFQ constraints and recommendation review,
+- persistence + limitations.
+
+Facilitator behavior:
+- Keep instructions short; avoid over-explaining design intent.
+- Pause after each segment for one “what felt easy/hard?” question.
+
+### 3) Task-based probing (10–15 min)
+Ask participant to perform realistic actions with minimal instruction.
+Examples:
+- “You have 30 minutes and medium energy—pick what to do next.”
+- “Find and update the task you added first.”
+- “Show how you’d identify what can be finished quickly.”
+
+Watch for:
+- hesitations, misclicks, backtracking,
+- misunderstanding of labels/scores/reason chips,
+- inability to recover from mistakes.
+
+### 4) Structured feedback (8–10 min)
+Use targeted prompts from [`feedback-questions.md`](./feedback-questions.md):
+- Most useful part,
+- Largest friction,
+- Must-have improvement before broader pilot,
+- Trust in TEFQ recommendation output.
+
+## Evidence capture standards
+Record evidence with enough detail to be actionable:
+- **Quote:** direct participant language when possible.
+- **Context:** task attempted, device/browser, and constraints used.
+- **Proof point:** timestamp or clear reproduction steps.
+- **Impact:** what outcome was blocked or slowed.
+
+Good evidence example:
+> “I can’t tell why this item is first in the queue” (12:42) after setting Time=30, Energy=Low; participant opened 3 items to inspect reasons.
+
+## Converting insights into issues
+Immediately after session:
+1. Fill synthesis template sections (observations, bugs, requests).
+2. Assign severity and priority rubric in template.
+3. Open/link GitHub issues for each high-signal finding.
+4. Add top findings to weekly report format.
+
+Tip: prioritize findings seen in multiple sessions or those blocking core flows.
+
+## Facilitation do/don't
+### Do
+- Ask neutral questions (“What are you expecting here?”).
+- Let participants narrate intent before intervening.
+- Distinguish usability confusion from feature gap.
+
+### Don’t
+- Lead participants to the “correct” interpretation.
+- Defend design decisions during the session.
+- Treat single anecdotal preferences as roadmap commitments.
+
+## Session close checklist (2 min)
+- Confirm final summary:
+  1) most useful,
+  2) biggest friction,
+  3) one must-have change.
+- Thank participant and confirm next steps for feedback usage.
+- Save notes with participant/session metadata for synthesis.

--- a/docs/pilot/kickoff-checklist.md
+++ b/docs/pilot/kickoff-checklist.md
@@ -1,0 +1,66 @@
+# Pilot Kickoff Checklist
+
+Use this checklist before each pilot session to keep setup consistent and avoid data contamination between participants.
+
+## 1) Session prep (before participant joins)
+- [ ] Confirm facilitator and note-taker roles for this session.
+- [ ] Open pilot materials:
+  - [ ] Onboarding packet: [`docs/pilot/onboarding.md`](./onboarding.md)
+  - [ ] Demo flow: [`docs/pilot/demo-script.md`](./demo-script.md)
+  - [ ] Interview prompts: [`docs/pilot/feedback-questions.md`](./feedback-questions.md)
+  - [ ] Synthesis template: [`docs/pilot/feedback-synthesis-template.md`](./feedback-synthesis-template.md)
+- [ ] Prepare a place to capture notes (doc, issue draft, or template copy).
+- [ ] Confirm meeting link + recording consent workflow (if recording is used).
+
+## 2) Environment + browser check
+- [ ] Open app: https://clay-agency.github.io/novel-task-tracker/
+- [ ] Use a supported browser version (latest Chrome/Safari/Edge/Firefox).
+- [ ] Use a clean profile/window if possible (recommended: incognito/private window for each participant).
+- [ ] Verify page loads with no obvious console/runtime errors.
+- [ ] Confirm viewport matches test intent (desktop and/or mobile width).
+
+## 3) Data reset (required between participants)
+Because this pilot uses `localStorage`, always reset data before a new session.
+
+### Quick reset option (recommended)
+- [ ] Open devtools console on the app page.
+- [ ] Run:
+
+```js
+localStorage.clear();
+location.reload();
+```
+
+### Browser UI reset option
+- [ ] Clear site data/storage for `clay-agency.github.io` in browser settings.
+- [ ] Reload and verify an empty starting state.
+
+## 4) Baseline sanity check (1–2 minutes)
+- [ ] Create 2–3 test tasks with varied duration/energy/priority.
+- [ ] Mark one complete, then reopen.
+- [ ] Set TEFQ constraints (time + energy) and verify recommendations appear.
+- [ ] Refresh once to confirm persistence behavior within the same browser profile.
+- [ ] Remove test tasks (or repeat reset) so participant starts clean.
+
+## 5) Participant kickoff confirmations
+At the beginning of the session, confirm:
+- [ ] Pilot purpose: workflow feedback, not polished production UX.
+- [ ] Storage model: local browser storage only (no account/sync/backend).
+- [ ] Session flow: orientation → demo/tasks → feedback questions.
+- [ ] Permission to ask follow-up questions and probe specific moments.
+
+## 6) Post-session handoff
+- [ ] Capture 3–5 key findings immediately after session end.
+- [ ] Classify each finding (bug vs feature request; severity/priority).
+- [ ] Add evidence (quotes, timestamps, repro steps).
+- [ ] Convert findings into GitHub issues and link in synthesis notes.
+- [ ] Add to weekly summary using [`docs/pilot/weekly-report-format.md`](./weekly-report-format.md).
+
+---
+
+## Fast preflight (60-second version)
+If time is short, do these minimum checks:
+1. [ ] Reset localStorage.
+2. [ ] Load app and create one task.
+3. [ ] Confirm TEFQ recommendations appear.
+4. [ ] Confirm note-taking template is ready.

--- a/docs/pilot/onboarding.md
+++ b/docs/pilot/onboarding.md
@@ -10,6 +10,8 @@ This onboarding guide is for pilot participants and facilitators to align on:
 - and current pilot limitations.
 
 ## Related pilot docs
+- Pilot kickoff checklist: [`docs/pilot/kickoff-checklist.md`](./kickoff-checklist.md)
+- Facilitator runbook: [`docs/pilot/facilitator-guide.md`](./facilitator-guide.md)
 - FAQ + troubleshooting: [`docs/pilot/faq-troubleshooting.md`](./faq-troubleshooting.md)
 - Feedback interview guide: [`docs/pilot/feedback-questions.md`](./feedback-questions.md)
 - Feedback synthesis template: [`docs/pilot/feedback-synthesis-template.md`](./feedback-synthesis-template.md)


### PR DESCRIPTION
## Summary
- add `docs/pilot/kickoff-checklist.md` for repeatable pilot preflight/session handoff
- add `docs/pilot/facilitator-guide.md` with run-of-show, evidence standards, and issue conversion flow
- link both docs from `docs/pilot/onboarding.md` related docs section

## Acceptance criteria mapping
- ✅ `docs/pilot/kickoff-checklist.md` added (setup, browser checks, data reset, confirmations)
- ✅ `docs/pilot/facilitator-guide.md` added (demo facilitation, prompts, recording/issue capture guidance)
- ✅ references existing `demo-script.md` and feedback templates
- ✅ linked from `docs/pilot/onboarding.md`

Closes #49
