### PR TITLE
feat: add in-app diagnostics footer with build metadata (closes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,13 @@ Use **Import JSON** to replace the current list with tasks from a JSON file. Sup
 - Raw array shape: `[...]`
 
 Import validation rejects malformed JSON or unsupported envelopes. Individual invalid task records are skipped during normalization.
+
+## Diagnostics footer / in-app support links (Issue #48)
+A lightweight diagnostics footer appears at the bottom of the app and shows:
+- app version (from `package.json` at build time)
+- short commit SHA (from `git rev-parse --short HEAD` at build time)
+
+It also includes quick links for:
+- **Report a bug**: GitHub bug-report template
+- **QA docs**: `docs/qa/` folder
+- **Export JSON**: jumps to the in-app export/import actions

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -80,6 +80,19 @@ async function createTask(
 test('supports core task lifecycle and persistence across reload', async ({ page }) => {
   await openWithFixedClock(page);
 
+  const diagnostics = page.getByLabel('Diagnostics and support');
+  await expect(diagnostics).toContainText(/Version v0\.1\.0/);
+  await expect(diagnostics).toContainText(/Commit (dev|[a-f0-9]{7})/);
+
+  await expect(page.getByRole('link', { name: 'Report a bug' })).toHaveAttribute(
+    'href',
+    'https://github.com/Clay-Agency/novel-task-tracker/issues/new?template=bug-report.md'
+  );
+  await expect(page.getByRole('link', { name: 'QA docs' })).toHaveAttribute(
+    'href',
+    'https://github.com/Clay-Agency/novel-task-tracker/tree/main/docs/qa'
+  );
+
   await createTask(page, { title: 'Persistent smoke task' });
 
   const taskList = page.getByRole('list', { name: 'Task list' });

--- a/src/App.css
+++ b/src/App.css
@@ -375,3 +375,45 @@ textarea:focus-visible {
     scroll-behavior: auto !important;
   }
 }
+
+.diagnostics-footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.4rem 0.85rem;
+  padding: 0.1rem 0.1rem 0;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.diagnostics-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.diagnostics-meta code {
+  font-size: 0.75rem;
+  padding: 0.05rem 0.35rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--glass-surface) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 86%, transparent);
+  color: var(--text-secondary);
+}
+
+.diagnostics-links {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+}
+
+.diagnostics-links a {
+  color: var(--text-secondary);
+}
+
+@media (min-width: 960px) {
+  .diagnostics-footer {
+    grid-column: 1 / -1;
+  }
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -123,6 +123,25 @@ describe('App core UI flows', () => {
     expect(screen.getByText(/no tefq-eligible tasks yet/i)).toBeInTheDocument();
   });
 
+
+  it('shows diagnostics footer metadata and support links', () => {
+    render(<App />);
+
+    expect(screen.getByText(/version/i)).toHaveTextContent(/v0\.1\.0/i);
+    expect(screen.getByText(/commit/i)).toHaveTextContent(/[a-f0-9]{7}|dev/i);
+
+    expect(screen.getByRole('link', { name: /report a bug/i })).toHaveAttribute(
+      'href',
+      'https://github.com/Clay-Agency/novel-task-tracker/issues/new?template=bug-report.md'
+    );
+    expect(screen.getByRole('link', { name: /qa docs/i })).toHaveAttribute(
+      'href',
+      'https://github.com/Clay-Agency/novel-task-tracker/tree/main/docs/qa'
+    );
+    expect(screen.getByRole('link', { name: /export json/i })).toHaveAttribute('href', '#data-portability');
+  });
+
+
   it('defaults to system theme when no preference is stored', () => {
     render(<App />);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,12 @@ const ENERGY_OPTIONS: { value: TaskEnergy; label: string }[] = [
   { value: TASK_ENERGY.HIGH, label: 'High' }
 ];
 
+
+const BUG_REPORT_URL = 'https://github.com/Clay-Agency/novel-task-tracker/issues/new?template=bug-report.md';
+const QA_DOCS_URL = 'https://github.com/Clay-Agency/novel-task-tracker/tree/main/docs/qa';
+const APP_VERSION = __APP_VERSION__;
+const APP_COMMIT_SHA = __APP_COMMIT_SHA__;
+
 function normalizeDescription(description: string): string | null {
   const trimmed = description.trim();
   return trimmed.length > 0 ? trimmed : null;
@@ -693,7 +699,7 @@ function App() {
           </div>
         </fieldset>
 
-        <div className="task-actions">
+        <div className="task-actions" id="data-portability">
           <button type="button" onClick={handleExportTasksJson}>
             Export JSON
           </button>
@@ -893,6 +899,22 @@ function App() {
           })}
         </ul>
       </section>
+
+      <footer className="diagnostics-footer" aria-label="Diagnostics and support">
+        <small className="diagnostics-meta">
+          Version <strong>v{APP_VERSION}</strong> · Commit <code>{APP_COMMIT_SHA}</code>
+        </small>
+        <nav className="diagnostics-links" aria-label="Diagnostics links">
+          <a href={BUG_REPORT_URL} target="_blank" rel="noreferrer noopener">
+            Report a bug
+          </a>
+          <a href={QA_DOCS_URL} target="_blank" rel="noreferrer noopener">
+            QA docs
+          </a>
+          <a href="#data-portability">Export JSON</a>
+        </nav>
+      </footer>
+
     </main>
   );
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,2 @@
+declare const __APP_VERSION__: string;
+declare const __APP_COMMIT_SHA__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,39 @@
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+
+interface PackageJson {
+  version?: string;
+}
+
+function readAppVersion(): string {
+  try {
+    const packageJson = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as PackageJson;
+    return packageJson.version?.trim() || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function readCommitSha(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim() || 'dev';
+  } catch {
+    return 'dev';
+  }
+}
+
+const appVersion = readAppVersion();
+const commitSha = readCommitSha();
 
 export default defineConfig({
   base: '/novel-task-tracker/',
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+    __APP_COMMIT_SHA__: JSON.stringify(commitSha)
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- inject app version (`package.json`) and short git commit SHA at build/test config time via Vite `define`
- render an unobtrusive responsive diagnostics footer showing `v<version>` + commit SHA
- add support links in footer for bug reporting template, QA docs, and in-app jump link to Export JSON
- add type declarations for injected globals and cover diagnostics in unit + e2e tests
- document diagnostics footer behavior in README

Closes #48

## Validation
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run e2e`

All passed locally.
