### PR TITLE
docs: standardize pilot URL single source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Baseline React scaffold for the Novel Task Tracker project.
 ## Live demo
 GitHub Pages: https://clay-agency.github.io/novel-task-tracker/
 
+Single source of truth for the pilot URL: [`docs/pilot/pilot-url.md`](./docs/pilot/pilot-url.md)
+
 ## Prerequisites
 - Node.js 18+
 - npm 9+

--- a/docs/pilot/kickoff-checklist.md
+++ b/docs/pilot/kickoff-checklist.md
@@ -13,7 +13,7 @@ Use this checklist before each pilot session to keep setup consistent and avoid 
 - [ ] Confirm meeting link + recording consent workflow (if recording is used).
 
 ## 2) Environment + browser check
-- [ ] Open app: https://clay-agency.github.io/novel-task-tracker/
+- [ ] Open app using the canonical pilot URL: [`docs/pilot/pilot-url.md`](./pilot-url.md)
 - [ ] Use a supported browser version (latest Chrome/Safari/Edge/Firefox).
 - [ ] Use a clean profile/window if possible (recommended: incognito/private window for each participant).
 - [ ] Verify page loads with no obvious console/runtime errors.

--- a/docs/pilot/onboarding.md
+++ b/docs/pilot/onboarding.md
@@ -18,7 +18,8 @@ This onboarding guide is for pilot participants and facilitators to align on:
 - Weekly report format: [`docs/pilot/weekly-report-format.md`](./weekly-report-format.md)
 
 ## Pilot app link
-- Live app: https://clay-agency.github.io/novel-task-tracker/
+- Canonical pilot URL source: [`docs/pilot/pilot-url.md`](./pilot-url.md)
+- Live app: use the URL listed in the canonical source above.
 
 ## Pilot test setup (2–3 minutes)
 1. Open the app link in a modern browser (Chrome/Safari/Edge/Firefox latest).

--- a/docs/pilot/pilot-url.md
+++ b/docs/pilot/pilot-url.md
@@ -1,0 +1,8 @@
+# Pilot URL (Single Source of Truth)
+
+Canonical pilot app URL for Novel Task Tracker:
+
+- https://clay-agency.github.io/novel-task-tracker/
+
+## Usage rule
+If the pilot URL changes, update this file first and then update any docs that reference it.


### PR DESCRIPTION
## Summary
- add `docs/pilot/pilot-url.md` as the canonical pilot URL source
- reference the canonical source in README
- update pilot onboarding + kickoff checklist to consume the canonical source

Refs #52