### PR TITLE
feat: add reset app data action with confirmation

### DIFF
--- a/docs/pilot/faq-troubleshooting.md
+++ b/docs/pilot/faq-troubleshooting.md
@@ -12,16 +12,21 @@ This guide helps pilot users quickly resolve common setup and usage issues.
 ### Can I safely reset my data?
 Yes. Use one of these options:
 
-1. **In-app reset by deleting tasks**
-   - Reopen the app and delete tasks one by one from the task list.
+1. **In-app reset (recommended for full reset)**
+   - Open the **Tasks** panel and select **Reset app data**.
+   - Confirm the prompt.
+   - The app clears local keys for tasks and theme preference (`novel-task-tracker/tasks`, `novel-task-tracker/theme`) and returns to an empty state.
+
+2. **In-app partial cleanup**
+   - Delete tasks one by one from the task list.
    - Best when you only want to remove some tasks.
 
-2. **Browser storage reset (full local reset for this app)**
+3. **Browser storage reset (manual full reset)**
    - Open browser DevTools → Application/Storage → Local Storage.
-   - Remove `novel-task-tracker/tasks`.
+   - Remove `novel-task-tracker/tasks` and `novel-task-tracker/theme`.
    - Refresh the app.
 
-> Tip: Storage reset is irreversible for this pilot build (no account backup/sync).
+> Tip: Reset is irreversible for this pilot build (no account backup/sync).
 
 ### What happens in Private/Incognito mode?
 - The app may work for the current session, but data usually clears when the private window is closed.

--- a/src/state/tasks.ts
+++ b/src/state/tasks.ts
@@ -420,6 +420,7 @@ function migratePersistedState(rawPersistedState: unknown): LoadTasksStateResult
 interface StorageLike {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
+  removeItem?: (key: string) => void;
 }
 
 function resolveStorage(storage?: StorageLike | null): StorageLike | null {
@@ -477,6 +478,20 @@ export function persistTasksState(state: TasksState, storage?: StorageLike | nul
         payload: normalizedState
       })
     );
+  } catch {
+    // localStorage quota/security failures should not crash the app
+  }
+}
+
+export function clearPersistedTasksState(storage?: StorageLike | null): void {
+  const resolvedStorage = resolveStorage(storage);
+
+  if (!resolvedStorage || typeof resolvedStorage.removeItem !== 'function') {
+    return;
+  }
+
+  try {
+    resolvedStorage.removeItem(TASKS_STORAGE_KEY);
   } catch {
     // localStorage quota/security failures should not crash the app
   }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -11,6 +11,7 @@ export const THEME_STORAGE_KEY = 'novel-task-tracker/theme';
 interface StorageLike {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
+  removeItem?: (key: string) => void;
 }
 
 export interface LoadThemePreferenceResult {
@@ -82,6 +83,20 @@ export function persistThemePreference(preference: ThemePreference, storage?: St
 
   try {
     resolvedStorage.setItem(THEME_STORAGE_KEY, preference);
+  } catch {
+    // localStorage quota/security failures should not crash the app
+  }
+}
+
+export function clearThemePreference(storage?: StorageLike | null): void {
+  const resolvedStorage = resolveStorage(storage);
+
+  if (!resolvedStorage || typeof resolvedStorage.removeItem !== 'function') {
+    return;
+  }
+
+  try {
+    resolvedStorage.removeItem(THEME_STORAGE_KEY);
   } catch {
     // localStorage quota/security failures should not crash the app
   }


### PR DESCRIPTION
## Summary\n- add a **Reset app data** control in Settings to wipe local task data and UI state\n- require user confirmation and provide success feedback after reset\n- add/refresh styling for destructive action affordance\n- extend unit and Playwright smoke coverage for reset behavior\n- document troubleshooting flow for pilot users\n\nCloses #54\n\n## Validation\n- npm run lint\n- npm run test\n- npm run build\n- npm run e2e\n