### PR TITLE
[Docs] Pilot consent + data handling notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Use these docs for pilot participant onboarding, live walkthroughs, structured f
 - [`docs/pilot/feedback-questions.md`](./docs/pilot/feedback-questions.md)
 - [`docs/pilot/feedback-synthesis-template.md`](./docs/pilot/feedback-synthesis-template.md)
 - [`docs/pilot/weekly-report-format.md`](./docs/pilot/weekly-report-format.md)
+- [`docs/pilot/consent-data-notice.md`](./docs/pilot/consent-data-notice.md)
 
 ## JSON export/import (Issue #40)
 Use **Export JSON** in the Tasks panel to download a versioned snapshot of your task list.

--- a/docs/pilot/consent-data-notice.md
+++ b/docs/pilot/consent-data-notice.md
@@ -1,0 +1,56 @@
+# Pilot Consent + Data Handling Notice
+
+Use this short notice before each pilot session so participants understand how data is handled in this prototype.
+
+## What this app does (pilot scope)
+Novel Task Tracker is a **client-only** web app prototype for personal task tracking and TEFQ (Time-Energy Fit Queue) recommendations.
+
+In this pilot build, the app runs entirely in your browser.
+
+## Where your data is stored
+- Task data is stored in your browser `localStorage`.
+- Current storage key: `novel-task-tracker/tasks`
+- Theme preference key: `novel-task-tracker/theme`
+- Data is local to the same browser profile and device.
+
+## What is not collected in this pilot
+- No account sign-up/login
+- No server-side task storage
+- No cloud sync across devices
+- No automatic analytics pipeline for task contents
+
+## How to reset / clear data
+Choose one of the following:
+
+1. **In-app reset (recommended full reset)**
+   - Open the **Tasks** panel.
+   - Select **Reset app data** and confirm.
+
+2. **Manual browser reset**
+   - Open browser DevTools → Application/Storage → Local Storage.
+   - Remove `novel-task-tracker/tasks` and `novel-task-tracker/theme`.
+   - Refresh the app.
+
+> Reset is irreversible in this pilot build.
+
+## How to export JSON backup
+- Use **Export JSON** in the Tasks panel.
+- Save the downloaded file locally.
+- You can re-import later with **Import JSON** in the same panel.
+
+## How to report bugs or share feedback
+- Bug report / QA finding / feature request templates:
+  - [`bug-report.md`](../../.github/ISSUE_TEMPLATE/bug-report.md)
+  - [`qa-finding.md`](../../.github/ISSUE_TEMPLATE/qa-finding.md)
+  - [`feature-request.md`](../../.github/ISSUE_TEMPLATE/feature-request.md)
+- Direct issue template chooser:
+  - https://github.com/Clay-Agency/novel-task-tracker/issues/new/choose
+- Pilot interview prompts:
+  - [`docs/pilot/feedback-questions.md`](./feedback-questions.md)
+
+## Consent acknowledgement (pilot-friendly)
+Use this exact text (or a close equivalent) before starting:
+
+> “This pilot app stores your task data only in this browser using local storage. There is no account and no server-side task storage in this build. You can stop at any time, and you can reset or clear your data at any point. Do you understand and consent to continue with this pilot session?”
+
+If recording is used, ask for recording consent separately.

--- a/docs/pilot/onboarding.md
+++ b/docs/pilot/onboarding.md
@@ -16,6 +16,7 @@ This onboarding guide is for pilot participants and facilitators to align on:
 - Feedback interview guide: [`docs/pilot/feedback-questions.md`](./feedback-questions.md)
 - Feedback synthesis template: [`docs/pilot/feedback-synthesis-template.md`](./feedback-synthesis-template.md)
 - Weekly report format: [`docs/pilot/weekly-report-format.md`](./weekly-report-format.md)
+- Consent + data handling notice: [`docs/pilot/consent-data-notice.md`](./consent-data-notice.md)
 
 ## Pilot app link
 - Canonical pilot URL source: [`docs/pilot/pilot-url.md`](./pilot-url.md)
@@ -35,6 +36,7 @@ This onboarding guide is for pilot participants and facilitators to align on:
 - Data is stored **locally in your browser** using `localStorage`.
 - Your tasks stay on the same browser/profile/device unless storage is cleared.
 - Data is not sent to a backend service in this pilot build.
+- Full participant notice: [`docs/pilot/consent-data-notice.md`](./consent-data-notice.md)
 
 ## What to focus on during pilot
 - Is task capture/editing/completion fast and intuitive?


### PR DESCRIPTION
## Summary
- add `docs/pilot/consent-data-notice.md` with pilot-friendly consent and data handling notice
- cover storage scope (`localStorage`), non-collection scope, reset/clear paths, JSON export backup, and bug/feedback reporting
- link the new notice from `docs/pilot/onboarding.md` and README pilot docs section

## Issue
Closes #58

## Type
- docs-only
