### PR TITLE
docs(pilot): recruitment criteria and outreach templates

### DIFF
--- a/docs/pilot/onboarding.md
+++ b/docs/pilot/onboarding.md
@@ -17,6 +17,7 @@ This onboarding guide is for pilot participants and facilitators to align on:
 - Feedback synthesis template: [`docs/pilot/feedback-synthesis-template.md`](./feedback-synthesis-template.md)
 - Weekly report format: [`docs/pilot/weekly-report-format.md`](./weekly-report-format.md)
 - Consent + data handling notice: [`docs/pilot/consent-data-notice.md`](./consent-data-notice.md)
+- Recruitment criteria + outreach templates: [`docs/pilot/recruitment-criteria-outreach.md`](./recruitment-criteria-outreach.md)
 
 ## Pilot app link
 - Canonical pilot URL source: [`docs/pilot/pilot-url.md`](./pilot-url.md)

--- a/docs/pilot/recruitment-criteria-outreach.md
+++ b/docs/pilot/recruitment-criteria-outreach.md
@@ -1,0 +1,132 @@
+# Pilot Recruitment Criteria + Outreach Templates
+
+## Purpose
+This document defines who to recruit for the Novel Task Tracker pilot and provides reusable outreach templates.
+
+## Ideal participant profiles
+Recruit a balanced mix of people who regularly manage personal work queues and can give practical product feedback.
+
+### Primary profiles
+1. **Individual contributors with self-managed task load**
+   - Examples: designers, engineers, marketers, operations associates, researchers, grad students
+   - Common pain points:
+     - too many scattered tasks across notes/apps
+     - uncertainty about what to do “right now”
+     - low follow-through during low-energy windows
+   - Device usage:
+     - desktop/laptop on weekdays
+     - mobile browser at least occasionally
+
+2. **Managers/team leads who juggle planning + execution**
+   - Common pain points:
+     - context switching and interruptions
+     - balancing urgent vs important work
+     - choosing realistic tasks for available time/energy
+   - Device usage:
+     - frequent desktop usage; may triage tasks on mobile
+
+3. **Productivity-tool experimenters**
+   - People who have used tools such as Notion, Todoist, Apple Reminders, Google Tasks, TickTick, etc.
+   - Valuable for comparative feedback (what feels better/worse and why)
+
+## Inclusion criteria
+Participants should meet **all required** and preferably several **preferred** criteria.
+
+### Required
+- Age 18+
+- Uses a task list/planner at least **3 days per week**
+- Has at least **8 active tasks** in a typical week
+- Uses a modern browser (Chrome/Safari/Edge/Firefox latest stable)
+- Can commit to:
+  - one onboarding session (10–15 minutes)
+  - 5–7 days of real usage
+  - one short feedback session or written feedback
+
+### Preferred
+- Uses both desktop and mobile during a normal week
+- Has experienced “task paralysis” or difficulty picking next action
+- Has switched productivity tools in the last 12 months
+- Comfortable sharing workflow feedback (without sensitive task details)
+
+## Exclusion criteria
+Exclude participants who are unlikely to provide reliable pilot signal for this stage.
+
+- Cannot commit to the pilot timeline or feedback touchpoints
+- Rarely tracks tasks (fewer than ~3 task-planning days/week)
+- Requires enterprise features not in pilot scope (accounts, team collaboration, cross-device sync)
+- Works in a context where browser-local storage use is disallowed by policy
+- Has direct decision authority over this pilot’s success metrics (to reduce bias)
+
+## Suggested cohort mix (first pilot batch)
+- Target: **8–12 participants**
+- Mix guideline:
+  - 4–6 individual contributors
+  - 2–3 managers/leads
+  - 2–3 heavy productivity-tool users
+- Platform/device coverage:
+  - at least 2 participants primarily on Safari
+  - at least 2 participants who will test mobile browser usage
+
+## Outreach templates
+
+> Replace bracketed placeholders before sending.
+
+### 1) Warm intro template
+**Subject:** Quick pilot invite: lightweight task workflow tool
+
+Hi [Name],
+
+I’m helping run a small pilot for **Novel Task Tracker**, a lightweight task app prototype focused on quick capture and choosing the next task based on available time/energy.
+
+Thought of you because [specific reason: e.g., “you’ve experimented with different task systems”]. Would you be open to a short pilot?
+
+What’s involved:
+- 10–15 min onboarding
+- 5–7 days of normal task usage
+- 15–20 min feedback at the end
+
+This is an early prototype (local browser storage, no accounts/sync yet), so we’re mainly learning what helps or frustrates real workflows.
+
+If you’re open, I can send details and schedule options. Totally okay to pass.
+
+Thanks!
+[Your Name]
+
+### 2) Cold outreach template
+**Subject:** Participant request: 1-week task app pilot (research)
+
+Hi [Name],
+
+I’m reaching out to invite you to a short research pilot for **Novel Task Tracker**, an early task-management prototype.
+
+We’re looking for people who actively manage weekly tasks and can share structured feedback on:
+- capture/edit/completion flow
+- “what should I do now?” recommendations
+- usability across desktop/mobile browser
+
+Pilot commitment:
+- onboarding: 10–15 minutes
+- usage period: 5–7 days
+- feedback: 15–20 minutes (or written form)
+
+Important context: pilot build is client-side only (no account system; data stored locally in browser).
+
+If interested, I can share the participant guide and next steps.
+
+Best,
+[Your Name]
+[Role / Team]
+
+### 3) Follow-up / reminder template
+**Subject:** Friendly follow-up: Novel Task Tracker pilot
+
+Hi [Name],
+
+Quick follow-up in case this got buried — would you be interested in joining the Novel Task Tracker pilot?
+
+It’s a lightweight 1-week test (10–15 min onboarding + short end feedback). We’re currently finalizing this cohort by [date].
+
+If timing isn’t good right now, no worries — a simple “pass” helps us plan.
+
+Thanks again,
+[Your Name]


### PR DESCRIPTION
## Summary
- add pilot recruitment criteria doc with ideal participant profiles
- define inclusion/exclusion criteria and suggested cohort mix
- add outreach templates for warm intro, cold outreach, and follow-up
- link new doc from docs/pilot/onboarding.md

## Testing
- docs-only change; not applicable

Closes #61