### PR TITLE
feat: opt-in local-only usage log + export UI (closes #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ Use **Import JSON** to replace the current list with tasks from a JSON file. Sup
 
 Import validation rejects malformed JSON or unsupported envelopes. Individual invalid task records are skipped during normalization.
 
+## Optional local usage log (Issue #60)
+The app includes an **opt-in** local usage log for pilot debugging.
+
+- Default is **OFF**.
+- Events include task CRUD actions, TEFQ control usage, JSON export/import, and reset actions.
+- Data is stored only in this browser profile (`localStorage`) and can be exported as JSON from the UI.
+- **No usage log data is sent to any server.**
+
 ## Diagnostics footer / in-app support links (Issue #48)
 A lightweight diagnostics footer appears at the bottom of the app and shows:
 - app version (from `package.json` at build time)

--- a/docs/pilot/consent-data-notice.md
+++ b/docs/pilot/consent-data-notice.md
@@ -11,6 +11,7 @@ In this pilot build, the app runs entirely in your browser.
 - Task data is stored in your browser `localStorage`.
 - Current storage key: `novel-task-tracker/tasks`
 - Theme preference key: `novel-task-tracker/theme`
+- Optional usage log key: `novel-task-tracker/usage-log` (default OFF / opt-in)
 - Data is local to the same browser profile and device.
 
 ## What is not collected in this pilot
@@ -18,6 +19,7 @@ In this pilot build, the app runs entirely in your browser.
 - No server-side task storage
 - No cloud sync across devices
 - No automatic analytics pipeline for task contents
+- No server transmission of usage-log events (if enabled, they remain local unless user exports JSON manually)
 
 ## How to reset / clear data
 Choose one of the following:
@@ -28,7 +30,7 @@ Choose one of the following:
 
 2. **Manual browser reset**
    - Open browser DevTools → Application/Storage → Local Storage.
-   - Remove `novel-task-tracker/tasks` and `novel-task-tracker/theme`.
+   - Remove `novel-task-tracker/tasks`, `novel-task-tracker/theme`, and `novel-task-tracker/usage-log`.
    - Refresh the app.
 
 > Reset is irreversible in this pilot build.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 
 const FIXED_NOW_ISO = '2026-02-19T00:00:00.000Z';
-const STORAGE_KEY = 'novel-task-tracker/tasks';
 
 async function openWithFixedClock(page: Page): Promise<void> {
   await page.addInitScript(({ fixedNowIso }) => {
@@ -30,7 +29,7 @@ async function openWithFixedClock(page: Page): Promise<void> {
   }, { fixedNowIso: FIXED_NOW_ISO });
 
   await page.goto('/');
-  await page.evaluate((storageKey) => window.localStorage.removeItem(storageKey), STORAGE_KEY);
+  await page.evaluate(() => window.localStorage.clear());
   await page.reload();
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -417,3 +417,36 @@ textarea:focus-visible {
     grid-column: 1 / -1;
   }
 }
+
+.usage-log {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px dashed color-mix(in srgb, var(--glass-border) 85%, transparent);
+}
+
+.usage-log h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.usage-log-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 0.35rem;
+}
+
+.usage-log-toggle input {
+  width: auto;
+}
+
+.usage-log-details {
+  margin: 0;
+  padding: 0.45rem 0.55rem;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--glass-surface) 85%, transparent);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 86%, transparent);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  overflow: auto;
+}

--- a/src/state/usageLog.test.ts
+++ b/src/state/usageLog.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  USAGE_EVENT_TYPES,
+  USAGE_LOG_STORAGE_KEY,
+  USAGE_LOG_STORAGE_VERSION,
+  appendUsageLogAction,
+  exportUsageLogJson,
+  initialUsageLogState,
+  loadUsageLogStateResult,
+  persistUsageLogState,
+  setUsageLogEnabledAction,
+  usageLogReducer
+} from './usageLog';
+
+describe('usage log state', () => {
+  const mockStorage = () => {
+    const storage = new Map<string, string>();
+    return {
+      getItem(key: string): string | null {
+        return storage.has(key) ? storage.get(key)! : null;
+      },
+      setItem(key: string, value: string): void {
+        storage.set(key, value);
+      }
+    };
+  };
+
+  it('defaults to disabled and does not append events while disabled', () => {
+    const appended = usageLogReducer(
+      initialUsageLogState,
+      appendUsageLogAction({ eventType: USAGE_EVENT_TYPES.TASK_CREATED, id: 'event-1', timestamp: '2026-02-19T00:00:00.000Z' })
+    );
+
+    expect(appended).toEqual(initialUsageLogState);
+  });
+
+  it('appends entries once enabled and persists versioned payload', () => {
+    const enabledState = usageLogReducer(initialUsageLogState, setUsageLogEnabledAction(true));
+    const appendedState = usageLogReducer(
+      enabledState,
+      appendUsageLogAction({
+        eventType: USAGE_EVENT_TYPES.TASK_CREATED,
+        details: { taskId: 't1' },
+        id: 'event-1',
+        timestamp: '2026-02-19T00:00:00.000Z'
+      })
+    );
+
+    expect(appendedState.entries).toHaveLength(1);
+    expect(appendedState.entries[0]).toMatchObject({
+      eventType: USAGE_EVENT_TYPES.TASK_CREATED,
+      details: { taskId: 't1' }
+    });
+
+    const storage = mockStorage();
+    persistUsageLogState(appendedState, storage);
+
+    expect(JSON.parse(storage.getItem(USAGE_LOG_STORAGE_KEY) ?? '{}')).toEqual({
+      version: USAGE_LOG_STORAGE_VERSION,
+      payload: appendedState
+    });
+  });
+
+  it('loads persisted state and skips persist on future versions', () => {
+    const storage = mockStorage();
+
+    storage.setItem(
+      USAGE_LOG_STORAGE_KEY,
+      JSON.stringify({
+        version: USAGE_LOG_STORAGE_VERSION,
+        payload: {
+          enabled: true,
+          entries: [
+            {
+              id: 'event-1',
+              timestamp: '2026-02-19T00:00:00.000Z',
+              eventType: USAGE_EVENT_TYPES.TEFQ_USED,
+              details: { source: 'energy-change' }
+            }
+          ]
+        }
+      })
+    );
+
+    expect(loadUsageLogStateResult(storage)).toEqual({
+      state: {
+        enabled: true,
+        entries: [
+          {
+            id: 'event-1',
+            timestamp: '2026-02-19T00:00:00.000Z',
+            eventType: USAGE_EVENT_TYPES.TEFQ_USED,
+            details: { source: 'energy-change' }
+          }
+        ]
+      },
+      skipInitialPersist: false
+    });
+
+    storage.setItem(USAGE_LOG_STORAGE_KEY, JSON.stringify({ version: USAGE_LOG_STORAGE_VERSION + 1, payload: {} }));
+
+    expect(loadUsageLogStateResult(storage)).toEqual({
+      state: initialUsageLogState,
+      skipInitialPersist: true
+    });
+  });
+
+  it('exports JSON payload', () => {
+    const json = exportUsageLogJson({
+      enabled: true,
+      entries: [
+        {
+          id: 'event-1',
+          timestamp: '2026-02-19T00:00:00.000Z',
+          eventType: USAGE_EVENT_TYPES.TASKS_EXPORTED,
+          details: { taskCount: 3 }
+        }
+      ]
+    });
+
+    expect(JSON.parse(json)).toEqual({
+      version: USAGE_LOG_STORAGE_VERSION,
+      payload: {
+        enabled: true,
+        entries: [
+          {
+            id: 'event-1',
+            timestamp: '2026-02-19T00:00:00.000Z',
+            eventType: USAGE_EVENT_TYPES.TASKS_EXPORTED,
+            details: { taskCount: 3 }
+          }
+        ]
+      }
+    });
+  });
+});

--- a/src/state/usageLog.ts
+++ b/src/state/usageLog.ts
@@ -1,0 +1,287 @@
+export const USAGE_LOG_STORAGE_KEY = 'novel-task-tracker/usage-log';
+export const USAGE_LOG_STORAGE_VERSION = 1;
+export const USAGE_LOG_MAX_ENTRIES = 300;
+
+export const USAGE_LOG_ACTIONS = {
+  SET_ENABLED: 'usageLog/setEnabled',
+  APPEND: 'usageLog/append',
+  RESET: 'usageLog/reset'
+} as const;
+
+export const USAGE_EVENT_TYPES = {
+  TASK_CREATED: 'task.created',
+  TASK_EDITED: 'task.edited',
+  TASK_COMPLETED: 'task.completed',
+  TASK_REOPENED: 'task.reopened',
+  TASK_DELETED: 'task.deleted',
+  TEFQ_USED: 'tefq.used',
+  TASKS_EXPORTED: 'tasks.exported',
+  TASKS_IMPORTED: 'tasks.imported',
+  APP_RESET: 'app.reset'
+} as const;
+
+export type UsageEventType = (typeof USAGE_EVENT_TYPES)[keyof typeof USAGE_EVENT_TYPES];
+
+export interface UsageLogEntry {
+  id: string;
+  timestamp: string;
+  eventType: UsageEventType;
+  details: Record<string, unknown> | null;
+}
+
+export interface UsageLogState {
+  enabled: boolean;
+  entries: UsageLogEntry[];
+}
+
+export interface LoadUsageLogStateResult {
+  state: UsageLogState;
+  skipInitialPersist: boolean;
+}
+
+export const initialUsageLogState: UsageLogState = {
+  enabled: false,
+  entries: []
+};
+
+const defaultLoadResult: LoadUsageLogStateResult = {
+  state: initialUsageLogState,
+  skipInitialPersist: false
+};
+
+type SetEnabledAction = {
+  type: (typeof USAGE_LOG_ACTIONS)['SET_ENABLED'];
+  payload: { enabled: boolean };
+};
+
+type AppendAction = {
+  type: (typeof USAGE_LOG_ACTIONS)['APPEND'];
+  payload: UsageLogEntry;
+};
+
+type ResetAction = {
+  type: (typeof USAGE_LOG_ACTIONS)['RESET'];
+};
+
+type UsageLogAction = SetEnabledAction | AppendAction | ResetAction;
+
+type AnyUsageLogAction = UsageLogAction | { type: string };
+
+export function setUsageLogEnabledAction(enabled: boolean): SetEnabledAction {
+  return {
+    type: USAGE_LOG_ACTIONS.SET_ENABLED,
+    payload: { enabled: Boolean(enabled) }
+  };
+}
+
+function randomId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function appendUsageLogAction({
+  eventType,
+  details = null,
+  timestamp = new Date().toISOString(),
+  id = randomId()
+}: {
+  eventType: UsageEventType;
+  details?: Record<string, unknown> | null;
+  timestamp?: string;
+  id?: string;
+}): AppendAction {
+  return {
+    type: USAGE_LOG_ACTIONS.APPEND,
+    payload: {
+      id,
+      timestamp,
+      eventType,
+      details
+    }
+  };
+}
+
+export function resetUsageLogAction(): ResetAction {
+  return {
+    type: USAGE_LOG_ACTIONS.RESET
+  };
+}
+
+export function usageLogReducer(state: UsageLogState = initialUsageLogState, action: AnyUsageLogAction): UsageLogState {
+  switch (action.type) {
+    case USAGE_LOG_ACTIONS.SET_ENABLED:
+      return {
+        ...state,
+        enabled: (action as SetEnabledAction).payload.enabled
+      };
+
+    case USAGE_LOG_ACTIONS.APPEND: {
+      if (!state.enabled) {
+        return state;
+      }
+
+      const nextEntries = [...state.entries, (action as AppendAction).payload];
+      return {
+        ...state,
+        entries: nextEntries.slice(-USAGE_LOG_MAX_ENTRIES)
+      };
+    }
+
+    case USAGE_LOG_ACTIONS.RESET:
+      return initialUsageLogState;
+
+    default:
+      return state;
+  }
+}
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?: (key: string) => void;
+}
+
+function resolveStorage(storage?: StorageLike | null): StorageLike | null {
+  if (storage !== undefined) {
+    return storage;
+  }
+
+  try {
+    return globalThis.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isUsageEventType(value: unknown): value is UsageEventType {
+  return typeof value === 'string' && Object.values(USAGE_EVENT_TYPES).includes(value as UsageEventType);
+}
+
+function normalizeEntry(rawEntry: unknown): UsageLogEntry | null {
+  if (!isObject(rawEntry)) {
+    return null;
+  }
+
+  const id = typeof rawEntry.id === 'string' ? rawEntry.id : null;
+  const timestamp = typeof rawEntry.timestamp === 'string' ? rawEntry.timestamp : null;
+  const eventType = rawEntry.eventType;
+
+  if (!id || !timestamp || !isUsageEventType(eventType)) {
+    return null;
+  }
+
+  return {
+    id,
+    timestamp,
+    eventType,
+    details: isObject(rawEntry.details) ? rawEntry.details : null
+  };
+}
+
+function migratePersistedUsageLogState(rawPersistedState: unknown): LoadUsageLogStateResult {
+  if (!isObject(rawPersistedState)) {
+    return defaultLoadResult;
+  }
+
+  const version = typeof rawPersistedState.version === 'number' ? rawPersistedState.version : 0;
+
+  if (version > USAGE_LOG_STORAGE_VERSION) {
+    return {
+      state: initialUsageLogState,
+      skipInitialPersist: true
+    };
+  }
+
+  const payload = isObject(rawPersistedState.payload) ? rawPersistedState.payload : rawPersistedState;
+  const enabled = Boolean(payload.enabled);
+  const entries = Array.isArray(payload.entries) ? payload.entries.map(normalizeEntry).filter((entry): entry is UsageLogEntry => entry !== null) : [];
+
+  return {
+    state: {
+      enabled,
+      entries: entries.slice(-USAGE_LOG_MAX_ENTRIES)
+    },
+    skipInitialPersist: false
+  };
+}
+
+export function loadUsageLogStateResult(storage?: StorageLike | null): LoadUsageLogStateResult {
+  const resolvedStorage = resolveStorage(storage);
+
+  if (!resolvedStorage || typeof resolvedStorage.getItem !== 'function') {
+    return defaultLoadResult;
+  }
+
+  try {
+    const raw = resolvedStorage.getItem(USAGE_LOG_STORAGE_KEY);
+    if (!raw) {
+      return defaultLoadResult;
+    }
+
+    return migratePersistedUsageLogState(JSON.parse(raw));
+  } catch {
+    return defaultLoadResult;
+  }
+}
+
+export function persistUsageLogState(state: UsageLogState, storage?: StorageLike | null): void {
+  const resolvedStorage = resolveStorage(storage);
+
+  if (!resolvedStorage || typeof resolvedStorage.setItem !== 'function') {
+    return;
+  }
+
+  const normalizedState: UsageLogState = {
+    enabled: Boolean(state?.enabled),
+    entries: Array.isArray(state?.entries) ? state.entries.slice(-USAGE_LOG_MAX_ENTRIES) : []
+  };
+
+  try {
+    resolvedStorage.setItem(
+      USAGE_LOG_STORAGE_KEY,
+      JSON.stringify({
+        version: USAGE_LOG_STORAGE_VERSION,
+        payload: normalizedState
+      })
+    );
+  } catch {
+    // localStorage quota/security failures should not crash the app
+  }
+}
+
+export function clearPersistedUsageLogState(storage?: StorageLike | null): void {
+  const resolvedStorage = resolveStorage(storage);
+
+  if (!resolvedStorage || typeof resolvedStorage.removeItem !== 'function') {
+    return;
+  }
+
+  try {
+    resolvedStorage.removeItem(USAGE_LOG_STORAGE_KEY);
+  } catch {
+    // localStorage quota/security failures should not crash the app
+  }
+}
+
+export function exportUsageLogJson(state: UsageLogState): string {
+  const normalizedState: UsageLogState = {
+    enabled: Boolean(state?.enabled),
+    entries: Array.isArray(state?.entries) ? state.entries.slice(-USAGE_LOG_MAX_ENTRIES) : []
+  };
+
+  return JSON.stringify(
+    {
+      version: USAGE_LOG_STORAGE_VERSION,
+      payload: normalizedState
+    },
+    null,
+    2
+  );
+}


### PR DESCRIPTION
## Summary
- adds an opt-in **local-only** usage log (`localStorage`) for key events
- captures task CRUD, TEFQ usage interactions, JSON export/import, and app reset events
- keeps logging **OFF by default** and adds in-app UI to enable/disable, view entries, and export log JSON
- documents clearly that usage log data stays local and is not sent to a server
- adds minimal unit + integration test coverage for usage-log behavior

## Implementation details
- new state module: `src/state/usageLog.ts`
  - versioned persistence (`novel-task-tracker/usage-log`)
  - reducer/actions for toggle + append
  - export helper for JSON downloads
- UI updates in `src/App.tsx`
  - usage-log controls and entry list
  - event logging hooks for task CRUD / TEFQ controls / export-import / reset
- docs updates
  - `README.md`
  - `docs/pilot/consent-data-notice.md`
- tests
  - `src/state/usageLog.test.ts`
  - `src/App.test.tsx` (opt-in + local persistence check)

## Validation evidence
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test` ✅ (39 passed)
- `npm run build` ✅
- `npm run e2e` ✅ (5 passed)
