### PR TITLE
ci: add scheduled weekly maintenance workflow

### DIFF
--- a/.github/workflows/maintenance-ci.yml
+++ b/.github/workflows/maintenance-ci.yml
@@ -1,0 +1,44 @@
+name: Scheduled CI Maintenance
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs weekly at 00:00 UTC every Monday.
+    - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  maintenance-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run typecheck
+        run: npm run typecheck
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Dependency vulnerability check (high/critical only)
+        # npm audit exits non-zero for vulnerabilities at or above --audit-level.
+        # Using --audit-level=high keeps noise low by ignoring low/moderate findings.
+        run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
## Summary
- add a new GitHub Actions workflow for scheduled CI maintenance
- trigger weekly via cron and support manual `workflow_dispatch`
- run the requested maintenance steps: `npm ci`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`
- add dependency vulnerability check with `npm audit --omit=dev --audit-level=high`

## Notes
- audit threshold is documented inline in the workflow comments
- this workflow only runs checks and does not auto-create issues or PRs (keeps noise low)

Closes #70
