### PR TITLE
[Ops] Automate Project #1 status sync on close/merge

### DIFF
--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -1,0 +1,396 @@
+name: Sync Clay Project status
+
+on:
+  pull_request:
+    types: [closed]
+  issues:
+    types: [closed]
+  schedule:
+    # Daily reconciliation (low-noise) to catch items added to the project after close/merge
+    - cron: '23 2 * * *'
+  workflow_dispatch:
+    inputs:
+      reconcile:
+        description: 'Reconcile all items in Project #1 (default true)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  projects: write
+
+concurrency:
+  group: project-status-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      ORG_LOGIN: Clay-Agency
+      PROJECT_NUMBER: '1'
+      RECONCILE: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.reconcile) }}
+    steps:
+      - name: Sync Project item fields (Status / Done date / Needs decision)
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const orgLogin = process.env.ORG_LOGIN;
+            const projectNumber = Number(process.env.PROJECT_NUMBER);
+            const reconcile = String(process.env.RECONCILE) === 'true';
+
+            const normalize = (s) => String(s || '').trim().toLowerCase();
+
+            function yyyyMmDd(dateLike) {
+              if (!dateLike) return null;
+              const d = new Date(dateLike);
+              if (Number.isNaN(d.getTime())) return null;
+              return d.toISOString().slice(0, 10);
+            }
+
+            async function getProjectMetadata() {
+              const query = `
+                query($org: String!, $number: Int!) {
+                  organization(login: $org) {
+                    projectV2(number: $number) {
+                      id
+                      title
+                      fields(first: 100) {
+                        nodes {
+                          __typename
+                          ... on ProjectV2FieldCommon {
+                            id
+                            name
+                            dataType
+                          }
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            dataType
+                            options {
+                              id
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `;
+
+              const res = await github.graphql(query, { org: orgLogin, number: projectNumber });
+              const project = res?.organization?.projectV2;
+              if (!project?.id) {
+                throw new Error(`Could not find org projectV2 ${orgLogin}#${projectNumber}`);
+              }
+
+              const fields = project.fields.nodes || [];
+
+              const byName = new Map();
+              for (const f of fields) byName.set(normalize(f.name), f);
+
+              const statusField = byName.get('status');
+              const doneDateField = byName.get('done date') || byName.get('done_date') || byName.get('done');
+              const needsDecisionField = byName.get('needs decision') || byName.get('needs_decision');
+
+              let statusDoneOptionId = null;
+              if (statusField?.dataType === 'SINGLE_SELECT') {
+                const opt = (statusField.options || []).find((o) => normalize(o.name) === 'done');
+                statusDoneOptionId = opt?.id || null;
+              }
+
+              return {
+                projectId: project.id,
+                projectTitle: project.title,
+                statusField,
+                statusDoneOptionId,
+                doneDateField,
+                needsDecisionField,
+              };
+            }
+
+            async function getProjectItemForContent(contentNodeId) {
+              const query = `
+                query($id: ID!) {
+                  node(id: $id) {
+                    __typename
+                    ... on Issue {
+                      url
+                      state
+                      closedAt
+                      projectItems(first: 50) {
+                        nodes { id project { id number } }
+                      }
+                    }
+                    ... on PullRequest {
+                      url
+                      state
+                      merged
+                      mergedAt
+                      closedAt
+                      projectItems(first: 50) {
+                        nodes { id project { id number } }
+                      }
+                    }
+                  }
+                }
+              `;
+
+              const res = await github.graphql(query, { id: contentNodeId });
+              const node = res?.node;
+              if (!node) return null;
+
+              const items = node?.projectItems?.nodes || [];
+              const item = items.find((it) => it?.project?.number === projectNumber);
+
+              return {
+                content: node,
+                itemId: item?.id || null,
+                projectId: item?.project?.id || null,
+              };
+            }
+
+            async function setSingleSelect({ projectId, itemId, fieldId, optionId }) {
+              const mutation = `
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(
+                    input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { singleSelectOptionId: $optionId }
+                    }
+                  ) {
+                    projectV2Item { id }
+                  }
+                }
+              `;
+              await github.graphql(mutation, { projectId, itemId, fieldId, optionId });
+            }
+
+            async function setDate({ projectId, itemId, fieldId, date }) {
+              const mutation = `
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+                  updateProjectV2ItemFieldValue(
+                    input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { date: $date }
+                    }
+                  ) {
+                    projectV2Item { id }
+                  }
+                }
+              `;
+              await github.graphql(mutation, { projectId, itemId, fieldId, date });
+            }
+
+            async function setBoolean({ projectId, itemId, fieldId, value }) {
+              const mutation = `
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Boolean!) {
+                  updateProjectV2ItemFieldValue(
+                    input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { boolean: $value }
+                    }
+                  ) {
+                    projectV2Item { id }
+                  }
+                }
+              `;
+              await github.graphql(mutation, { projectId, itemId, fieldId, value });
+            }
+
+            async function setNeedsDecisionFalse(meta, { projectId, itemId }) {
+              const f = meta.needsDecisionField;
+              if (!f?.id) return;
+
+              if (f.dataType === 'BOOLEAN') {
+                await setBoolean({ projectId, itemId, fieldId: f.id, value: false });
+                return;
+              }
+
+              if (f.dataType === 'SINGLE_SELECT') {
+                const options = f.options || [];
+                const falseNames = new Set(['false', 'no', 'n', '0', 'none', 'clear']);
+                const opt = options.find((o) => falseNames.has(normalize(o.name)));
+                if (opt?.id) {
+                  await setSingleSelect({ projectId, itemId, fieldId: f.id, optionId: opt.id });
+                } else {
+                  core.warning(`Needs decision is SINGLE_SELECT but no obvious false option found; skipping clear.`);
+                }
+                return;
+              }
+
+              core.warning(`Needs decision field has unsupported dataType=${f.dataType}; skipping clear.`);
+            }
+
+            async function syncOneItem(meta, { projectId, itemId, doneDate }) {
+              if (!projectId || !itemId) return;
+
+              const mutations = [];
+
+              if (meta.statusField?.id && meta.statusDoneOptionId) {
+                mutations.push(
+                  setSingleSelect({
+                    projectId,
+                    itemId,
+                    fieldId: meta.statusField.id,
+                    optionId: meta.statusDoneOptionId,
+                  })
+                );
+              } else {
+                core.warning(`Status field or Done option not found; skipping Status update.`);
+              }
+
+              if (meta.doneDateField?.id) {
+                const date = doneDate || yyyyMmDd(new Date());
+                if (date) {
+                  mutations.push(setDate({ projectId, itemId, fieldId: meta.doneDateField.id, date }));
+                }
+              } else {
+                core.warning(`Done date field not found; skipping Done date update.`);
+              }
+
+              // Clear Needs decision
+              mutations.push(setNeedsDecisionFalse(meta, { projectId, itemId }));
+
+              // Execute sequentially to make troubleshooting easier & reduce rate-limit spikes
+              for (const m of mutations) {
+                try {
+                  await m;
+                } catch (e) {
+                  core.warning(`Field update failed: ${e?.message || e}`);
+                }
+              }
+            }
+
+            async function reconcileProject(meta) {
+              core.info(`Reconciling items in ${orgLogin} Project #${projectNumber} (${meta.projectTitle})`);
+
+              const query = `
+                query($projectId: ID!, $after: String) {
+                  node(id: $projectId) {
+                    ... on ProjectV2 {
+                      items(first: 50, after: $after) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                          id
+                          content {
+                            __typename
+                            ... on Issue {
+                              url
+                              state
+                              closedAt
+                            }
+                            ... on PullRequest {
+                              url
+                              state
+                              merged
+                              mergedAt
+                              closedAt
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `;
+
+              let after = null;
+              let processed = 0;
+              let updated = 0;
+
+              while (true) {
+                const res = await github.graphql(query, { projectId: meta.projectId, after });
+                const items = res?.node?.items?.nodes || [];
+                const pageInfo = res?.node?.items?.pageInfo;
+
+                for (const it of items) {
+                  processed += 1;
+                  const c = it.content;
+                  if (!c) continue;
+
+                  let shouldMarkDone = false;
+                  let doneDate = null;
+
+                  if (c.__typename === 'Issue') {
+                    shouldMarkDone = c.state === 'CLOSED';
+                    doneDate = yyyyMmDd(c.closedAt);
+                  } else if (c.__typename === 'PullRequest') {
+                    shouldMarkDone = Boolean(c.merged);
+                    doneDate = yyyyMmDd(c.mergedAt || c.closedAt);
+                  }
+
+                  if (!shouldMarkDone) continue;
+
+                  core.info(`Syncing closed content: ${c.url}`);
+                  await syncOneItem(meta, { projectId: meta.projectId, itemId: it.id, doneDate });
+                  updated += 1;
+
+                  if (updated >= 200) {
+                    core.warning('Safety stop: reached 200 updates in one run.');
+                    return { processed, updated, stopped: true };
+                  }
+                }
+
+                if (!pageInfo?.hasNextPage) break;
+                after = pageInfo.endCursor;
+
+                // Safety: don't scan unbounded projects
+                if (processed >= 1000) {
+                  core.warning('Safety stop: scanned 1000 items; stopping.');
+                  return { processed, updated, stopped: true };
+                }
+              }
+
+              return { processed, updated, stopped: false };
+            }
+
+            // --- Main ---
+            const meta = await getProjectMetadata();
+
+            if (reconcile) {
+              const res = await reconcileProject(meta);
+              core.info(`Reconcile complete. scanned=${res.processed}, updated=${res.updated}, stopped=${res.stopped}`);
+              return;
+            }
+
+            let contentNodeId = null;
+            if (context.eventName === 'issues') {
+              contentNodeId = context.payload?.issue?.node_id;
+            } else if (context.eventName === 'pull_request') {
+              contentNodeId = context.payload?.pull_request?.node_id;
+              const merged = Boolean(context.payload?.pull_request?.merged);
+              if (!merged) {
+                core.info('PR was closed but not merged; nothing to do.');
+                return;
+              }
+            }
+
+            if (!contentNodeId) {
+              core.info('No content node id found in event payload; nothing to do.');
+              return;
+            }
+
+            const { content, itemId, projectId } = await getProjectItemForContent(contentNodeId);
+            if (!itemId) {
+              core.info('Content is not in Project #1; nothing to do.');
+              return;
+            }
+
+            const doneDate = yyyyMmDd(
+              content.__typename === 'PullRequest' ? (content.mergedAt || content.closedAt) : content.closedAt
+            );
+
+            core.info(`Syncing Project item for ${content.url}`);
+            await syncOneItem(meta, { projectId: meta.projectId || projectId, itemId, doneDate });

--- a/docs/ops/project-status-sync.md
+++ b/docs/ops/project-status-sync.md
@@ -1,0 +1,43 @@
+# Project status sync (Clay Project #1)
+
+This repo uses a low-noise GitHub Action to keep **Clay-Agency Project #1** in sync when work completes.
+
+## What it does
+
+When an item in Project #1 is closed/merged, the workflow updates the corresponding Project item fields:
+
+- **Merged PRs** → `Status = Done`, `Done date = mergedAt` (YYYY-MM-DD)
+- **Closed issues** → `Status = Done`, `Done date = closedAt` (YYYY-MM-DD)
+- Clears **Needs decision** (sets to `false` when the field is a boolean; otherwise tries to select a "No/False" option)
+
+## How it runs
+
+Workflow: `.github/workflows/project-status-sync.yml`
+
+Triggers:
+
+- `pull_request.closed` (only acts when `merged == true`)
+- `issues.closed`
+- `schedule` (daily reconciliation) to catch cases where an issue/PR is added to the project after it was already closed.
+- `workflow_dispatch` (manual run)
+
+## Permissions / secrets
+
+- Uses the built-in `GITHUB_TOKEN`.
+- Workflow permissions:
+  - `projects: write`
+  - `issues: read`
+  - `pull-requests: read`
+  - `contents: read`
+
+No additional secrets are required.
+
+## Notes / limitations
+
+- The workflow only updates items that are already in **Clay-Agency Project #1**.
+- It assumes the project has fields named:
+  - `Status` (single-select with an option named `Done`)
+  - `Done date` (date field)
+  - `Needs decision` (boolean preferred)
+
+If the project uses different names, adjust the matching logic in the workflow script.


### PR DESCRIPTION
Closes #76.

Adds a low-noise GitHub Action that updates Clay-Agency Project #1 when issues are closed or PRs are merged:
- Status -> Done
- Done date populated
- Clears Needs decision

Also includes a daily scheduled reconciliation run + docs.