### PR TITLE
Clarify missing Projects v2 auth failure message

### DIFF
--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -68,7 +68,7 @@ jobs:
         if: ${{ steps.app-token.outputs.token == '' && steps.auth.outputs.has_pat != 'true' }}
         shell: bash
         run: |
-          echo "::error title=No Projects v2 auth token available::This workflow must authenticate to GitHub Projects v2 (org ProjectV2). Configure ONE of the following: (A) GitHub App (preferred): vars.PROJECTS_APP_ID (or secrets.PROJECTS_APP_ID) AND secrets.PROJECTS_APP_PRIVATE_KEY; OR (B) PAT: secrets.PROJECT_STATUS_SYNC_TOKEN. See https://github.com/Clay-Agency/novel-task-tracker/issues/80"
+          echo "::error title=No Projects v2 auth token available::Configure Projects v2 auth: GitHub App (preferred) set vars.PROJECTS_APP_ID + secrets.PROJECTS_APP_PRIVATE_KEY, OR PAT set secrets.PROJECT_STATUS_SYNC_TOKEN. Docs: https://github.com/Clay-Agency/novel-task-tracker/blob/main/docs/ops/projects-v2-auth.md ; Issue #80: https://github.com/Clay-Agency/novel-task-tracker/issues/80"
           exit 1
 
       - name: Sync Project item fields (Status / Done date / Needs decision)


### PR DESCRIPTION
Fixes #86.

Updates the "Fail (missing Projects v2 auth)" step message to:
- link the durable auth doc and #80
- include a quickstart for GitHub App vs PAT