### PR TITLE
Issue #109: Rate-limited reminder comment when Projects v2 auth missing

### DIFF
--- a/.github/workflows/projects-v2-auth-preflight.yml
+++ b/.github/workflows/projects-v2-auth-preflight.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const core = require('/core');
+            const core = require('@actions/core');
             const issueNumber = 80;
             const marker = '<!-- projects-v2-auth-missing-reminder:v1 -->';
             const rateLimitDays = 7;


### PR DESCRIPTION
Closes #109.

## What
When the daily **Projects v2 auth preflight** detects that neither GitHub App auth (vars.PROJECTS_APP_ID + secrets.PROJECTS_APP_PRIVATE_KEY) nor PAT fallback (secrets.PROJECT_STATUS_SYNC_TOKEN) is configured, it now posts a low-noise reminder comment to **#80** with:
- quickstart for GitHub App (preferred) + PAT fallback
- links to #80, the runbook, and the **Projects v2 auth smoke test** workflow

## Noise control
- Marker string: `<!-- projects-v2-auth-missing-reminder:v1 -->`
- Rate limit: the workflow scans existing comments on #80 for the marker and skips posting if the most recent marker comment is **< 7 days old**.

## How to test
1. Ensure the repo has no Projects v2 auth configured (no vars/secrets listed above).
2. Run **Projects v2 auth preflight** via `workflow_dispatch`.
3. Expected:
   - workflow fails with an actionable error
   - a comment is posted to https://github.com/Clay-Agency/novel-task-tracker/issues/80 (unless a marker comment was posted in the last 7 days)

## Implementation notes
- Uses repo-scoped `GITHUB_TOKEN` with `issues: write`.
- No secrets are printed (only presence booleans + links).
