### PR TITLE
CI: avoid failing project status sync when Projects v2 auth missing

### DIFF
--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -5,9 +5,6 @@ on:
     types: [closed]
   issues:
     types: [closed]
-  schedule:
-    # Daily reconciliation (low-noise) to catch items added to the project after close/merge
-    - cron: '23 2 * * *'
   workflow_dispatch:
     inputs:
       reconcile:
@@ -63,12 +60,13 @@ jobs:
           PAT_TOKEN: ${{ secrets.PROJECT_STATUS_SYNC_TOKEN }}
         run: node .github/scripts/select-projects-token.cjs
 
-      - name: Fail (missing Projects v2 auth)
+      - name: Skip (missing Projects v2 auth)
         if: ${{ steps.token.outputs.token == '' }}
         shell: bash
         run: |
-          echo "::error title=No Projects v2 auth token available::Configure Projects v2 auth: GitHub App (preferred) set vars.PROJECTS_APP_ID + secrets.PROJECTS_APP_PRIVATE_KEY, OR PAT set secrets.PROJECT_STATUS_SYNC_TOKEN. Docs: https://github.com/Clay-Agency/novel-task-tracker/blob/main/docs/ops/projects-v2-auth-runbook.md ; Issue #80: https://github.com/Clay-Agency/novel-task-tracker/issues/80"
-          exit 1
+          echo "::warning title=No Projects v2 auth token available::Skipping Project status sync because no Projects v2 auth token is configured. Configure Projects v2 auth: GitHub App (preferred) set vars.PROJECTS_APP_ID + secrets.PROJECTS_APP_PRIVATE_KEY, OR PAT set secrets.PROJECT_STATUS_SYNC_TOKEN. Runbook: https://github.com/Clay-Agency/novel-task-tracker/blob/main/docs/ops/projects-v2-auth-runbook.md ; Tracking issue #80: https://github.com/Clay-Agency/novel-task-tracker/issues/80"
+          echo "Note: The scheduled auth check is handled by the 'Projects v2 auth preflight' workflow. See issue #121: https://github.com/Clay-Agency/novel-task-tracker/issues/121"
+          exit 0
 
       - name: Sync Project item fields (Status / Done date / Needs decision)
         uses: actions/github-script@v7


### PR DESCRIPTION
Closes #121.

Changes:
- Remove the scheduled trigger from `.github/workflows/project-status-sync.yml` (scheduled checks live in `.github/workflows/projects-v2-auth-preflight.yml`).
- When Projects v2 auth is missing, emit a `::warning::` with links to the runbook + #80 and exit 0 (skip the sync).

This prevents red Actions runs on issue/PR close events when auth isn’t configured, while preflight remains the single scheduled, failing signal.
