### PR TITLE
Standardize needs-decision labeling guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -9,6 +9,10 @@ assignees: ''
 ## Summary
 A short description of the bug.
 
+
+## Needs decision?
+- [ ] This requires a decision from Clay (if checked: set Project field `Needs decision: True` and add label `needs-decision`)
+
 ## Environment
 - App version/commit:
 - Browser + version:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -9,6 +9,10 @@ assignees: ''
 ## Problem to solve
 What user/problem gap are we addressing?
 
+
+## Needs decision?
+- [ ] This requires a decision from Clay (if checked: set Project field `Needs decision: True` and add label `needs-decision`)
+
 ## Proposed solution
 Describe the desired behavior or change.
 

--- a/.github/ISSUE_TEMPLATE/qa-finding.md
+++ b/.github/ISSUE_TEMPLATE/qa-finding.md
@@ -9,6 +9,10 @@ assignees: ''
 ## Finding summary
 Describe the observed issue/risk.
 
+
+## Needs decision?
+- [ ] This requires a decision from Clay (if checked: set Project field `Needs decision: True` and add label `needs-decision`)
+
 ## Checklist mapping (required)
 Link the exact checklist item/section under `docs/qa/` that this finding maps to.
 - Checklist document:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,10 @@ Use the issue templates under `.github/ISSUE_TEMPLATE/`:
 - **QA finding** (`qa-finding.md`): findings mapped to checklist docs in `docs/qa/`
 - **Feature request** (`feature-request.md`): enhancement proposals with problem + success criteria
 
+## Needs-decision convention
+
+If an issue is blocked on a **decision from Clay**, set the Project field `Needs decision: True` and apply the repo label `needs-decision` (easy filtering outside the Projects UI).
+
 For QA findings (and QA-discovered bugs), include a direct link to the relevant checklist section:
 - `docs/qa/responsive-qa-checklist.md`
 - `docs/qa/pilot-readiness-cross-browser-plan.md`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Single source of truth for the pilot URL: [`docs/pilot/pilot-url.md`](./docs/pil
 
 ## Open decisions
 
+Quick filter: [`label:needs-decision`](https://github.com/Clay-Agency/novel-task-tracker/issues?q=is%3Aopen+label%3Aneeds-decision)
+
 - **Projects v2 auth for Project #1 automation**: decide GitHub App vs PAT (so Actions can update Project fields like Done date/Needs decision). [Decision record](https://github.com/Clay-Agency/novel-task-tracker/issues/80#issuecomment-3941544627)
 - **Priority taxonomy (P0–P3 vs P0–P2)**: decide whether to add P3 to Project #1 (or collapse P3 into P2). [Decision record](https://github.com/Clay-Agency/novel-task-tracker/issues/126#issuecomment-3986370623)
 


### PR DESCRIPTION
Closes #133

Minimal documentation + template guidance: when Project field `Needs decision: True`, also apply repo label `needs-decision` for easy filtering outside Projects UI.