### PR TITLE
CI: add internal Markdown link checker (Closes #139)

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,29 @@
+name: Markdown link check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  check-markdown-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # We only validate internal/relative links to keep this workflow fast and non-flaky.
+      # External URLs are intentionally skipped.
+      - name: Check internal Markdown links (README.md + docs/**)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: true
+          args: >-
+            --no-progress
+            --offline
+            --exclude '^https?://'
+            --exclude '^mailto:'
+            README.md docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,20 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 - `docs/qa/responsive-qa-checklist.md`
 - `docs/qa/pilot-readiness-cross-browser-plan.md`
 
+## Markdown link check
+
+CI validates **internal/relative** links in `README.md` and `docs/**` (external URLs are intentionally skipped to avoid flaky failures).
+
+Run locally:
+
+```bash
+# Install lychee first (one option):
+#   brew install lychee
+# or: cargo install lychee
+
+lychee --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
+```
+
 ## 2-stage review process (required)
 
 ### Stage 1 — Self-review (author, xhigh reasoning)


### PR DESCRIPTION
Closes #139

## What
- Adds a lightweight GitHub Actions workflow that checks **internal/relative** Markdown links in `README.md` and `docs/**` using **lychee**.
- Skips external URLs to avoid flaky CI failures (offline mode + exclude http/mailto).

## Why
- Prevents broken doc links from landing in `main` without introducing network-dependent checks.

## Local run
See `CONTRIBUTING.md` → "Markdown link check".