### PR TITLE
DX: add verify:quick script and fix workflow YAML parsing

### DIFF
--- a/.github/workflows/pages-smoke-check.yml
+++ b/.github/workflows/pages-smoke-check.yml
@@ -30,11 +30,11 @@ jobs:
           fi
 
           url=$(python3 - <<'PY'
-import re, pathlib
-text = pathlib.Path('docs/pilot/pilot-url.md').read_text(encoding='utf-8')
-m = re.search(r"https?://[^ )]+", text)
-print(m.group(0) if m else "")
-PY
+          import re, pathlib
+          text = pathlib.Path('docs/pilot/pilot-url.md').read_text(encoding='utf-8')
+          m = re.search(r"https?://[^ )]+", text)
+          print(m.group(0) if m else "")
+          PY
           )
 
           if [[ -z "${url:-}" ]]; then
@@ -87,11 +87,11 @@ PY
           fi
 
           base_origin=$(python3 - <<'PY'
-import os, urllib.parse
-u = os.environ['PILOT_URL']
-sp = urllib.parse.urlsplit(u)
-print(f"{sp.scheme}://{sp.netloc}")
-PY
+          import os, urllib.parse
+          u = os.environ['PILOT_URL']
+          sp = urllib.parse.urlsplit(u)
+          print(f"{sp.scheme}://{sp.netloc}")
+          PY
           )
 
           # Check at least one JS asset returns 200.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,19 @@ docker run --rm -v "$(pwd)":/workdir -w /workdir \
 ```
 
 
+## Local verification commands
+
+Use the quick check during development, and full check before final review:
+
+```bash
+# Fast inner-loop verification (no build)
+npm run verify:quick
+
+# Full pre-merge verification (includes build)
+npm run verify:core
+```
+
+
 ## 2-stage review process (required)
 
 ### Stage 1 — Self-review (author, xhigh reasoning)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "e2e": "playwright test",
     "check:workflows": "ruby -e 'require \"yaml\"; Dir[\".github/workflows/*.{yml,yaml}\"].sort.each { |f| YAML.load_file(f); puts \"OK #{f}\" }'",
     "docs:links": "lychee --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
-    "verify:core": "npm run check:workflows && npm run lint && npm run typecheck && npm test && npm run build"
+    "verify:quick": "npm run check:workflows && npm run lint && npm run typecheck && npm test",
+    "verify:core": "npm run verify:quick && npm run build"
   },
   "dependencies": {
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- add `npm run verify:quick` for fast local checks (workflow YAML + lint + typecheck + tests)
- refactor `verify:core` to reuse `verify:quick` and then run build
- document quick vs full verification usage in `CONTRIBUTING.md`
- fix YAML indentation in `.github/workflows/pages-smoke-check.yml` so `check:workflows` parses all workflow files

Closes #148

## Verification
- `npm run verify:quick`
- `npm run verify:core`
