### PR TITLE
Docs: clarify Docker readiness for docs link-check fallback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,15 @@ Run locally:
 npm run docs:links
 
 # Option B: Docker (no local lychee install required)
+#   Optional readiness check (daemon reachable):
+#   docker info >/dev/null
+
 docker run --rm -v "$(pwd)":/workdir -w /workdir \
   ghcr.io/lycheeverse/lychee:latest \
   --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
+
+# If you see "Cannot connect to the Docker daemon", start Docker/OrbStack first,
+# then rerun the command.
 ```
 
 


### PR DESCRIPTION
## Summary
- add a Docker daemon readiness pre-check (`docker info >/dev/null`) near the Markdown link-check fallback command
- add concise troubleshooting guidance for the common "Cannot connect to the Docker daemon" error
- keep Docker fallback command aligned with CI lychee args

Closes #150

## Verification
- `npm run verify:quick`
