### PR TITLE
DX: add docs:links:docker npm script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,12 @@ npm run docs:links
 #   Optional readiness check (daemon reachable):
 #   docker info >/dev/null
 
-docker run --rm -v "$(pwd)":/workdir -w /workdir \
-  ghcr.io/lycheeverse/lychee:latest \
-  --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
+npm run docs:links:docker
+
+# (Equivalent direct command)
+# docker run --rm -v "$(pwd)":/workdir -w /workdir \
+#   ghcr.io/lycheeverse/lychee:latest \
+#   --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
 
 # If you see "Cannot connect to the Docker daemon", start Docker/OrbStack first,
 # then rerun the command.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "e2e": "playwright test",
     "check:workflows": "ruby -e 'require \"yaml\"; Dir[\".github/workflows/*.{yml,yaml}\"].sort.each { |f| YAML.load_file(f); puts \"OK #{f}\" }'",
     "docs:links": "lychee --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
+    "docs:links:docker": "docker run --rm -v \"$PWD\":/workdir -w /workdir ghcr.io/lycheeverse/lychee:latest --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
     "verify:quick": "npm run check:workflows && npm run lint && npm run typecheck && npm test",
     "verify:core": "npm run verify:quick && npm run build"
   },


### PR DESCRIPTION
## Summary
- add `npm run docs:links:docker` as a first-class wrapper for Docker-based lychee link checks
- keep Docker lychee args aligned with CI and `docs:links`
- update `CONTRIBUTING.md` to use the npm wrapper for Docker fallback and keep equivalent direct command as reference

Closes #152

## Verification
- `npm run verify:quick`
