### PR TITLE
CI: run verify:core on pull_request

### DIFF
--- a/.github/workflows/verify-core.yml
+++ b/.github/workflows/verify-core.yml
@@ -1,0 +1,37 @@
+name: Verify (core)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-core-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-core:
+    name: npm run verify:core
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify (core)
+        run: npm run verify:core


### PR DESCRIPTION
Fixes #158.

Adds a dedicated GitHub Actions workflow that runs `npm ci` + `npm run verify:core` on:
- `pull_request`
- `push` to `main`

Uses `actions/setup-node` with npm cache for speed.

Result: PRs always get at least one visible CI check in the PR UI.
