### PR TITLE
Fix #170: label needs-decision snapshot issue as automation

### DIFF
--- a/.github/scripts/needs-decision-snapshot-lib.ts
+++ b/.github/scripts/needs-decision-snapshot-lib.ts
@@ -11,6 +11,9 @@ export type GitHubSearchItem = {
 export const SNAPSHOT_TITLE = 'Needs-decision snapshot (automated)';
 export const LABEL = 'needs-decision';
 
+// Label applied to the canonical snapshot issue so it can be excluded from Project auto-add rules.
+export const SNAPSHOT_ISSUE_LABEL = 'automation';
+
 export function fmtDate(dateLike?: string): string {
   if (!dateLike) return '';
   const d = new Date(dateLike);

--- a/.github/scripts/needs-decision-snapshot.ts
+++ b/.github/scripts/needs-decision-snapshot.ts
@@ -8,8 +8,9 @@
  * - Low-noise: updates one existing issue body (or creates it once if missing).
  */
 
-import { buildBody, LABEL, SNAPSHOT_TITLE, splitPrsAndIssues } from './needs-decision-snapshot-lib.js';
+import { buildBody, LABEL, SNAPSHOT_ISSUE_LABEL, SNAPSHOT_TITLE, splitPrsAndIssues } from './needs-decision-snapshot-lib.js';
 import type { GitHubSearchItem } from './needs-decision-snapshot-lib.js';
+import { pathToFileURL } from 'node:url';
 
 type GitHubSearchResponse = {
   total_count: number;
@@ -98,6 +99,7 @@ async function createIssue(owner: string, repo: string, body: string): Promise<G
     body: JSON.stringify({
       title: SNAPSHOT_TITLE,
       body,
+      labels: [SNAPSHOT_ISSUE_LABEL],
     }),
   });
 }
@@ -124,6 +126,14 @@ async function updateIssue(params: {
       body,
       ...(state ? { state } : {}),
     }),
+  });
+}
+
+async function addLabelsToIssue(owner: string, repo: string, issueNumber: number, labels: string[]): Promise<void> {
+  await ghFetch<unknown>(`/repos/${owner}/${repo}/issues/${issueNumber}/labels`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ labels }),
   });
 }
 
@@ -158,7 +168,7 @@ async function findOrCreateSnapshotIssueNumber(owner: string, repo: string, repo
   return created.number;
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const { owner, repo, full: repoFull } = repoFromEnv();
   const dryRun = toBool(process.env.DRY_RUN, false);
 
@@ -182,10 +192,13 @@ async function main(): Promise<void> {
   }
 
   const updated = await updateIssue({ owner, repo, issueNumber, body, reopenIfClosed: true });
+  await addLabelsToIssue(owner, repo, issueNumber, [SNAPSHOT_ISSUE_LABEL]);
   console.log(`Updated snapshot issue: ${updated.html_url}`);
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exitCode = 1;
-});
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  });
+}

--- a/test/needs-decision-snapshot.test.ts
+++ b/test/needs-decision-snapshot.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { main } from '../.github/scripts/needs-decision-snapshot';
+
+function okJson(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+describe('needs-decision snapshot script', () => {
+  const envBackup = { ...process.env };
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env = { ...envBackup };
+    process.env.GITHUB_TOKEN = 'test-token';
+    process.env.GITHUB_REPOSITORY = 'Clay-Agency/novel-task-tracker';
+    delete process.env.SNAPSHOT_ISSUE_NUMBER;
+    delete process.env.NEEDS_DECISION_SNAPSHOT_ISSUE_NUMBER;
+    process.env.DRY_RUN = 'false';
+  });
+
+  afterEach(() => {
+    process.env = { ...envBackup };
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('labels the snapshot issue when it is first created, and also re-applies label on update', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const u = new URL(String(url));
+      const path = u.pathname;
+      const method = (init?.method || 'GET').toUpperCase();
+      calls.push({ url: u.toString(), init });
+
+      if (path === '/search/issues' && method === 'GET') {
+        const q = u.searchParams.get('q') || '';
+        // First query: open items labeled needs-decision
+        if (q.includes('label:"needs-decision"')) {
+          return okJson({ total_count: 0, incomplete_results: false, items: [] });
+        }
+        // Second query: find existing snapshot issue by title
+        if (q.includes('in:title') && q.includes('Needs-decision snapshot (automated)')) {
+          return okJson({ total_count: 0, incomplete_results: false, items: [] });
+        }
+        throw new Error(`Unexpected search query: ${q}`);
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues' && method === 'POST') {
+        const body = JSON.parse(String(init?.body || '{}'));
+        expect(body.title).toBe('Needs-decision snapshot (automated)');
+        expect(body.labels).toEqual(['automation']);
+        return okJson({
+          number: 77,
+          title: body.title,
+          state: 'open',
+          html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/77',
+          body: body.body,
+        });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/77' && method === 'GET') {
+        return okJson({
+          number: 77,
+          title: 'Needs-decision snapshot (automated)',
+          state: 'open',
+          html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/77',
+          body: 'x',
+        });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/77' && method === 'PATCH') {
+        return okJson({
+          number: 77,
+          title: 'Needs-decision snapshot (automated)',
+          state: 'open',
+          html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/77',
+          body: 'updated',
+        });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/77/labels' && method === 'POST') {
+        const body = JSON.parse(String(init?.body || '{}'));
+        expect(body.labels).toEqual(['automation']);
+        return okJson([{ name: 'automation' }]);
+      }
+
+      throw new Error(`Unexpected fetch: ${method} ${path}`);
+    }) as unknown as typeof fetch;
+
+    await main();
+
+    const labelCalls = calls.filter((c) => c.url.includes('/issues/77/labels'));
+    expect(labelCalls.length).toBe(1);
+  });
+
+  it('re-applies the automation label on every update (even when the snapshot issue already exists)', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const u = new URL(String(url));
+      const path = u.pathname;
+      const method = (init?.method || 'GET').toUpperCase();
+      calls.push({ url: u.toString(), init });
+
+      if (path === '/search/issues' && method === 'GET') {
+        const q = u.searchParams.get('q') || '';
+        // First query: open items labeled needs-decision
+        if (q.includes('label:"needs-decision"')) {
+          return okJson({ total_count: 0, incomplete_results: false, items: [] });
+        }
+        // Second query: find existing snapshot issue by title
+        if (q.includes('in:title') && q.includes('Needs-decision snapshot (automated)')) {
+          return okJson({
+            total_count: 1,
+            incomplete_results: false,
+            items: [
+              {
+                number: 50,
+                title: 'Needs-decision snapshot (automated)',
+                html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/50',
+              },
+            ],
+          });
+        }
+        throw new Error(`Unexpected search query: ${q}`);
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/50' && method === 'GET') {
+        return okJson({
+          number: 50,
+          title: 'Needs-decision snapshot (automated)',
+          state: 'open',
+          html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/50',
+          body: 'x',
+        });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/50' && method === 'PATCH') {
+        return okJson({
+          number: 50,
+          title: 'Needs-decision snapshot (automated)',
+          state: 'open',
+          html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/50',
+          body: 'updated',
+        });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/50/labels' && method === 'POST') {
+        const body = JSON.parse(String(init?.body || '{}'));
+        expect(body.labels).toEqual(['automation']);
+        return okJson([{ name: 'automation' }]);
+      }
+
+      throw new Error(`Unexpected fetch: ${method} ${path}`);
+    }) as unknown as typeof fetch;
+
+    await main();
+
+    const labelCalls = calls.filter((c) => c.url.includes('/issues/50/labels'));
+    expect(labelCalls.length).toBe(1);
+
+    const createCalls = calls.filter((c) => c.url.endsWith('/repos/Clay-Agency/novel-task-tracker/issues') && (c.init?.method || 'GET').toUpperCase() === 'POST');
+    expect(createCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Ensure the canonical needs-decision snapshot issue always carries the `automation` label so it can be excluded from Project #1 auto-add rules (e.g. `-label:automation`).

## Changes
- Add `SNAPSHOT_ISSUE_LABEL = 'automation'`
- Apply label on issue creation
- Re-apply label on every update run
- Add unit tests covering both create + update paths

## Notes
Uses only repo-scoped `GITHUB_TOKEN` (Issues API).
