### PR TITLE
ci: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
Adds workflow_dispatch to CI workflow so it can be run manually from the Actions tab.\n\nCloses #185.