### PR TITLE
Fix docs anchor drift in project-status-sync warnings

### DIFF
--- a/.github/scripts/project-status-sync.cjs
+++ b/.github/scripts/project-status-sync.cjs
@@ -1,7 +1,10 @@
 'use strict';
 
+const SCHEMA_HELP_DOC = 'docs/ops/projects-v2-auth.md';
+const SCHEMA_HELP_ANCHOR = 'fieldoption-mismatch-warnings';
+
 function schemaHelp() {
-  return 'See docs/ops/projects-v2-auth.md#fieldoption-mismatch-warnings';
+  return `See ${SCHEMA_HELP_DOC}#${SCHEMA_HELP_ANCHOR}`;
 }
 
 function normalize(s) {
@@ -400,6 +403,9 @@ async function run({ github, context, core, env }) {
 }
 
 module.exports = {
+  SCHEMA_HELP_DOC,
+  SCHEMA_HELP_ANCHOR,
+  schemaHelp,
   normalize,
   yyyyMmDd,
   mapProjectFields,

--- a/docs/ops/projects-v2-auth.md
+++ b/docs/ops/projects-v2-auth.md
@@ -155,6 +155,8 @@ Usually indicates:
 - Error like: `Could not find org projectV2 Clay-Agency#1`.
 - Verify the workflow’s `ORG_LOGIN` and `PROJECT_NUMBER` values and that your token can read org Projects.
 
+<a id="fieldoption-mismatch-warnings"></a>
+
 ### Field/option mismatch warnings
 
 The workflow expects (by default):

--- a/src/ops/projectStatusSync.test.ts
+++ b/src/ops/projectStatusSync.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { getProjectMetadata, syncOneItem } = require('../../.github/scripts/project-status-sync.cjs');
+const { getProjectMetadata, syncOneItem, schemaHelp } = require('../../.github/scripts/project-status-sync.cjs');
 
 describe('project-status-sync', () => {
   it('maps Status/Done date/Needs decision fields from project metadata (incl. Done option id)', async () => {
@@ -221,7 +221,7 @@ describe('project-status-sync', () => {
     expect(core.warning).toHaveBeenCalledTimes(1);
     const msg = String(core.warning.mock.calls[0][0]);
     expect(msg).toContain('Status field missing option "Done"');
-    expect(msg).toContain('docs/ops/projects-v2-auth.md#fieldoption-mismatch-warnings');
+    expect(msg).toContain(schemaHelp());
     expect(msg).toContain('Completed');
   });
 
@@ -251,7 +251,7 @@ describe('project-status-sync', () => {
     expect(core.warning).toHaveBeenCalledTimes(1);
     const msg = String(core.warning.mock.calls[0][0]);
     expect(msg).toContain('missing field "Status"');
-    expect(msg).toContain('docs/ops/projects-v2-auth.md#fieldoption-mismatch-warnings');
+    expect(msg).toContain(schemaHelp());
   });
 
   it('warns with a runbook link when Done date field is missing', async () => {
@@ -288,7 +288,7 @@ describe('project-status-sync', () => {
     expect(core.warning).toHaveBeenCalledTimes(1);
     const msg = String(core.warning.mock.calls[0][0]);
     expect(msg).toContain('Done date field not found');
-    expect(msg).toContain('docs/ops/projects-v2-auth.md#fieldoption-mismatch-warnings');
+    expect(msg).toContain(schemaHelp());
   });
 
   it('warns (with options + runbook link) when Needs decision is SINGLE_SELECT but has no obvious false option', async () => {
@@ -334,7 +334,7 @@ describe('project-status-sync', () => {
     expect(core.warning).toHaveBeenCalledTimes(1);
     const msg = String(core.warning.mock.calls[0][0]);
     expect(msg).toContain('Needs decision is SINGLE_SELECT but no obvious false option found');
-    expect(msg).toContain('docs/ops/projects-v2-auth.md#fieldoption-mismatch-warnings');
+    expect(msg).toContain(schemaHelp());
     expect(msg).toContain('Maybe');
   });
 

--- a/src/ops/projectStatusSyncDocsGuard.test.ts
+++ b/src/ops/projectStatusSyncDocsGuard.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { schemaHelp, SCHEMA_HELP_DOC, SCHEMA_HELP_ANCHOR } = require('../../.github/scripts/project-status-sync.cjs');
+
+describe('project-status-sync docs link guard', () => {
+  it('schemaHelp points to a stable anchor that exists in the docs', () => {
+    expect(schemaHelp()).toBe(`See ${SCHEMA_HELP_DOC}#${SCHEMA_HELP_ANCHOR}`);
+
+    const absDocPath = path.resolve(process.cwd(), SCHEMA_HELP_DOC);
+    expect(fs.existsSync(absDocPath)).toBe(true);
+
+    const md = fs.readFileSync(absDocPath, 'utf8');
+    const anchorRe = new RegExp(`id=["']${SCHEMA_HELP_ANCHOR}["']`);
+    expect(md).toMatch(anchorRe);
+  });
+});


### PR DESCRIPTION
Closes #195.

What changed:
- Export `schemaHelp()` + constants from `.github/scripts/project-status-sync.cjs` so tests reference the canonical warning link.
- Add an explicit HTML anchor (`<a id="fieldoption-mismatch-warnings"></a>`) to `docs/ops/projects-v2-auth.md` for a stable slug.
- Add a small Vitest guard (`src/ops/projectStatusSyncDocsGuard.test.ts`) that fails if the docs anchor referenced by `schemaHelp()` goes missing.
- Update existing tests to assert against `schemaHelp()` (avoids hard-coded link drift).

Evidence:
- `npm run verify:core` passes locally.
- CI green on this PR: https://github.com/Clay-Agency/novel-task-tracker/actions/runs/22781022372
