### PR TITLE
Docs: Status-only fallback for Projects workflows

### DIFF
--- a/docs/ops/projects-v2-auth-runbook.md
+++ b/docs/ops/projects-v2-auth-runbook.md
@@ -7,7 +7,40 @@ GitHub’s built-in Actions token (`GITHUB_TOKEN`) **cannot** mutate **organizat
 - Preferred: **GitHub App** (`actions/create-github-app-token@v2`)
 - Fallback: **PAT** (only if you cannot use a GitHub App)
 
+Related (status-only): GitHub Projects built-in workflows can set **Status=Done** on close/merge **without any App/PAT** (see **Status-only fallback** below).
+
 Related issues: #80, #95, #175.
+
+---
+
+## Status-only fallback (no App/PAT)
+
+If Projects v2 auth (#80) is **not configured**, our repo automation **cannot** update custom fields (ex: **Done date**, **Needs decision**).
+
+However, GitHub Projects has **built-in Project workflows** that can still set **Status = Done** when an Issue is closed or a PR is merged — with **no token**.
+
+### Enable in the Project UI
+
+1. Open **Clay-Agency Project #1**.
+2. Click **… (More)** → **Workflows**.
+3. Enable the default workflows for:
+   - **Item closed** → set **Status** to **Done**
+   - **Pull request merged** (or **Pull request closed**, depending on your UI) → set **Status** to **Done**
+
+If the workflow asks for a field/option:
+- Field: `Status`
+- Option: `Done`
+
+### What this does / does not do
+
+✅ Works without App/PAT:
+- Updates the Project item’s **Status** to **Done** on close/merge.
+
+❌ Limitations (why #80 still matters):
+- Cannot set **Done date**
+- Cannot clear **Needs decision**
+
+Recommended usage: treat this as a **temporary stopgap** until #80 (GitHub App auth) is set up.
 
 ---
 

--- a/docs/ops/projects-v2-auth.md
+++ b/docs/ops/projects-v2-auth.md
@@ -11,6 +11,9 @@ GitHub’s built-in Actions token (`secrets.GITHUB_TOKEN`) **cannot** mutate **o
 - **Option A (preferred): GitHub App installation token** (least privilege, easy to rotate)
 - **Option B: PAT fallback** (Personal Access Token)
 
+> **Status-only fallback:** if you only need Project items to move to **Status = Done** on issue close / PR merge (no Done date / Needs decision updates), you can enable GitHub Projects built-in workflows instead of configuring App/PAT.
+> See: [Status-only fallback](./projects-v2-auth-runbook.md#status-only-fallback-no-apppat).
+
 Primary consumer:
 - [Project status sync workflow](./project-status-sync.md) (`.github/workflows/project-status-sync.yml`)
 


### PR DESCRIPTION
Adds a concise **Status-only fallback** section to the Projects v2 auth runbook, explaining how to use GitHub Projects built-in workflows (close/merge → Status=Done) without App/PAT, plus limitations (no Done date / no Needs decision clearing).

Closes #198.