### PR TITLE
docs: reduce Actions noise for Status-only fallback

### DIFF
--- a/.github/scripts/needs-decision-snapshot.ts
+++ b/.github/scripts/needs-decision-snapshot.ts
@@ -137,6 +137,67 @@ async function addLabelsToIssue(owner: string, repo: string, issueNumber: number
   });
 }
 
+async function addCommentToIssue(owner: string, repo: string, issueNumber: number, body: string): Promise<void> {
+  await ghFetch<unknown>(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ body }),
+  });
+}
+
+async function closeIssue(owner: string, repo: string, issueNumber: number): Promise<void> {
+  await ghFetch<unknown>(`/repos/${owner}/${repo}/issues/${issueNumber}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ state: 'closed' }),
+  });
+}
+
+async function closeSupersededSnapshotIssues(params: {
+  owner: string;
+  repo: string;
+  repoFull: string;
+  canonicalIssueNumber: number;
+  dryRun: boolean;
+}): Promise<number> {
+  const { owner, repo, repoFull, canonicalIssueNumber, dryRun } = params;
+
+  const query = `repo:${repoFull} is:issue is:open in:title "${SNAPSHOT_TITLE}"`;
+  const hits = await searchAllIssues(query, 2);
+
+  const toClose = hits
+    .filter((it) => it.number !== canonicalIssueNumber)
+    .sort((a, b) => a.number - b.number);
+
+  if (toClose.length === 0) return 0;
+
+  const marker = 'needs-decision-snapshot: do-not-edit';
+  let closed = 0;
+
+  for (const it of toClose) {
+    const issue = await getIssue(owner, repo, it.number);
+
+    // Safety: only close the automated snapshot issues we own.
+    if (issue.title !== SNAPSHOT_TITLE) continue;
+    if (!((issue.body || '').includes(marker))) continue;
+
+    const comment = `Superseded by #${canonicalIssueNumber}. Closing to keep a single canonical snapshot issue.`;
+
+    if (dryRun) {
+      console.log(`[dry-run] Would close superseded snapshot issue #${issue.number} (superseded by #${canonicalIssueNumber}).`);
+      closed += 1;
+      continue;
+    }
+
+    await addCommentToIssue(owner, repo, issue.number, comment);
+    await closeIssue(owner, repo, issue.number);
+    console.log(`Closed superseded snapshot issue #${issue.number}.`);
+    closed += 1;
+  }
+
+  return closed;
+}
+
 async function findOrCreateSnapshotIssueNumber(owner: string, repo: string, repoFull: string): Promise<number> {
   const envIssue = process.env.SNAPSHOT_ISSUE_NUMBER || process.env.NEEDS_DECISION_SNAPSHOT_ISSUE_NUMBER;
   if (envIssue) {
@@ -188,12 +249,31 @@ export async function main(): Promise<void> {
   if (dryRun) {
     console.log(`[dry-run] Would update issue #${issueNumber} with ${prs.length} PR(s) and ${issues.length} issue(s).`);
     console.log(body.slice(0, 2000));
+
+    await closeSupersededSnapshotIssues({
+      owner,
+      repo,
+      repoFull,
+      canonicalIssueNumber: issueNumber,
+      dryRun: true,
+    });
+
     return;
   }
 
   const updated = await updateIssue({ owner, repo, issueNumber, body, reopenIfClosed: true });
   await addLabelsToIssue(owner, repo, issueNumber, [SNAPSHOT_ISSUE_LABEL]);
+
+  const closed = await closeSupersededSnapshotIssues({
+    owner,
+    repo,
+    repoFull,
+    canonicalIssueNumber: issueNumber,
+    dryRun: false,
+  });
+
   console.log(`Updated snapshot issue: ${updated.html_url}`);
+  if (closed > 0) console.log(`Closed ${closed} superseded snapshot issue(s).`);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {

--- a/docs/ops/projects-v2-auth-runbook.md
+++ b/docs/ops/projects-v2-auth-runbook.md
@@ -42,6 +42,31 @@ If the workflow asks for a field/option:
 
 Recommended usage: treat this as a **temporary stopgap** until #80 (GitHub App auth) is set up.
 
+### Reducing Actions noise (if you intentionally stay Status-only)
+
+If you choose this fallback and **do not** configure Projects v2 auth (#80), you may still see GitHub Actions activity:
+
+- **Projects v2 auth preflight** runs on a **daily schedule** and will **fail** with a “missing auth” error.
+- **Sync Clay Project status** runs on **Issue/PR close** and will typically **warn + skip** when no token is available.
+
+Low-risk ways to keep noise low:
+
+1) **Disable the scheduled trigger** (keep manual `workflow_dispatch`)
+   - File: [`.github/workflows/projects-v2-auth-preflight.yml`](../../.github/workflows/projects-v2-auth-preflight.yml)
+   - Remove (or comment out) the `on.schedule` block.
+   - Click-path: **Code** → open the file → **Edit (pencil)** → commit to your default branch.
+
+2) **Disable specific workflows in the repo UI**
+   - Click-path: **Actions** → select a workflow (ex: **Projects v2 auth preflight**) → **…** → **Disable workflow**.
+   - Suggested disables if you only want built-in Project workflows:
+     - **Projects v2 auth preflight**
+     - **Sync Clay Project status**
+
+3) **Ignore the warnings as expected**
+   - The warnings/skips are safe if you’re relying on GitHub Projects built-in workflows for **Status = Done**.
+   - When you’re ready for full automation (Done date / Needs decision), follow #80 and re-enable the workflows.
+
+
 ---
 
 ## What to configure (exact names)

--- a/test/needs-decision-snapshot.test.ts
+++ b/test/needs-decision-snapshot.test.ts
@@ -170,4 +170,100 @@ describe('needs-decision snapshot script', () => {
     const createCalls = calls.filter((c) => c.url.endsWith('/repos/Clay-Agency/novel-task-tracker/issues') && (c.init?.method || 'GET').toUpperCase() === 'POST');
     expect(createCalls.length).toBe(0);
   });
+
+  it('closes older open snapshot issues so only the canonical snapshot remains open', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const u = new URL(String(url));
+      const path = u.pathname;
+      const method = (init?.method || 'GET').toUpperCase();
+      calls.push({ url: u.toString(), init });
+
+      if (path === '/search/issues' && method === 'GET') {
+        const q = u.searchParams.get('q') || '';
+        // First query: open items labeled needs-decision
+        if (q.includes('label:"needs-decision"')) {
+          return okJson({ total_count: 0, incomplete_results: false, items: [] });
+        }
+        // Snapshot query: returns canonical + one duplicate
+        if (q.includes('in:title') && q.includes('Needs-decision snapshot (automated)')) {
+          return okJson({
+            total_count: 2,
+            incomplete_results: false,
+            items: [
+              { number: 50, title: 'Needs-decision snapshot (automated)', html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/50' },
+              { number: 60, title: 'Needs-decision snapshot (automated)', html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/60' },
+            ],
+          });
+        }
+        throw new Error(`Unexpected search query: ${q}`);
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/50' && method === 'GET') {
+        return okJson({
+          number: 50,
+          title: 'Needs-decision snapshot (automated)',
+          state: 'open',
+          html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/50',
+          body: '<!-- needs-decision-snapshot: do-not-edit -->\nold',
+        });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/50' && method === 'PATCH') {
+        return okJson({
+          number: 50,
+          title: 'Needs-decision snapshot (automated)',
+          state: 'open',
+          html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/50',
+          body: 'updated',
+        });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/50/labels' && method === 'POST') {
+        const body = JSON.parse(String(init?.body || '{}'));
+        expect(body.labels).toEqual(['automation']);
+        return okJson([{ name: 'automation' }]);
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/60' && method === 'GET') {
+        return okJson({
+          number: 60,
+          title: 'Needs-decision snapshot (automated)',
+          state: 'open',
+          html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/60',
+          body: '<!-- needs-decision-snapshot: do-not-edit -->\ndupe',
+        });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/60/comments' && method === 'POST') {
+        const body = JSON.parse(String(init?.body || '{}'));
+        expect(String(body.body)).toContain('Superseded by #50');
+        return okJson({ id: 1 });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/60' && method === 'PATCH') {
+        const body = JSON.parse(String(init?.body || '{}'));
+        expect(body.state).toBe('closed');
+        return okJson({
+          number: 60,
+          title: 'Needs-decision snapshot (automated)',
+          state: 'closed',
+          html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/60',
+          body: 'x',
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${method} ${path}`);
+    }) as unknown as typeof fetch;
+
+    await main();
+
+    const closedCalls = calls.filter((c) => c.url.includes('/issues/60') && (c.init?.method || 'GET').toUpperCase() === 'PATCH');
+    expect(closedCalls.length).toBe(1);
+
+    const commentCalls = calls.filter((c) => c.url.includes('/issues/60/comments'));
+    expect(commentCalls.length).toBe(1);
+  });
+
 });


### PR DESCRIPTION
Fixes #204.

Adds a short note to the Status-only fallback section explaining why auth-related workflows still run (preflight scheduled fail + status-sync warn/skip) and how to reduce Actions noise (disable cron trigger, disable workflows via UI, or ignore).

Docs-only change.