### PR TITLE
docs: clarify Project #1 fields (Owner agent / Needs decision / Evidence)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,16 @@ Use the issue templates under `.github/ISSUE_TEMPLATE/`:
 - **QA finding** (`qa-finding.md`): findings mapped to checklist docs in `docs/qa/`
 - **Feature request** (`feature-request.md`): enhancement proposals with problem + success criteria
 
+## Project #1 board fields (Owner agent / Needs decision / Evidence)
+
+When you add an issue/PR to the **Clay-Agency org Project #1** board, keep these fields accurate:
+
+- **Owner agent**: the agent accountable for the next step. Set when work starts; clear if unowned.
+- **Needs decision**: set `True` (and apply label `needs-decision`) only when progress is blocked on an explicit Clay decision. Put the decision question + options in the issue.
+- **Evidence**: paste the key links that justify the current state (PR, CI run, screenshots/GIFs, decision record). Keep it short; one item per line.
+
+Details: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
+
 ## Needs-decision convention
 
 If an issue/PR is blocked on an **explicit decision from Clay**, apply the repo label `needs-decision`.
@@ -46,7 +56,7 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 ## Ops runbooks (Project #1 automation)
 
 - [Projects v2 auth runbook](./docs/ops/projects-v2-auth-runbook.md): Use when configuring or debugging GitHub Actions auth for workflows that read/update the Clay-Agency org Project #1 (GraphQL `ProjectV2`).
-- [Project #1 field conventions](./docs/ops/project-1-field-conventions.md): Use when triaging work on the Project #1 board or building automation that writes project fields (Status, Priority, Owner agent, Needs decision).
+- [Project #1 field conventions](./docs/ops/project-1-field-conventions.md): Use when triaging work on the Project #1 board or building automation that writes project fields (Status, Priority, Owner agent, Needs decision, Evidence).
 
 ## Markdown link check
 

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -53,3 +53,15 @@ Conventions:
   - (optional) a recommended default
   - links/evidence (can also be mirrored into the project `Evidence` field)
 - Set back to **False** once the decision is made or no longer blocks progress.
+
+## Evidence (text)
+
+Conventions:
+- Use this field as the **living link hub** for the issue/PR. Keep it short (typically 1–5 lines).
+- Prefer durable URLs (PR link, Actions run link, doc/decision record path, screenshot/GIF link).
+- Suggested format (one item per line):
+  - `PR: <url>`
+  - `CI: <url>`
+  - `Decision record: docs/decisions/DR-XXXX-...md`
+  - `QA evidence: <url or docs/qa/...#anchor>`
+- When moving work to **Review** or **Done**, make sure the Evidence field includes the relevant PR/merge reference.


### PR DESCRIPTION
Closes #206.\n\nAdds a concise CONTRIBUTING note on how we use Clay-Agency org Project #1 fields (Owner agent, Needs decision, Evidence) and updates the field conventions doc to include Evidence guidance.