### PR TITLE
[Ops] Exclude automation-labeled items from Project #1 auto-add

### DIFF
--- a/.github/scripts/project-autoadd-exclude-automation.cjs
+++ b/.github/scripts/project-autoadd-exclude-automation.cjs
@@ -1,0 +1,215 @@
+'use strict';
+
+const DEFAULT_RETRY_ATTEMPTS = 6;
+const DEFAULT_RETRY_DELAY_MS = 10_000;
+
+function normalize(s) {
+  return String(s || '').trim().toLowerCase();
+}
+
+function toBool(v, defaultValue = false) {
+  if (v == null) return defaultValue;
+  const s = String(v).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y', 'on'].includes(s)) return true;
+  if (['0', 'false', 'no', 'n', 'off'].includes(s)) return false;
+  return defaultValue;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function labelsFromContext({ context }) {
+  if (context.eventName === 'issues') {
+    return (context.payload?.issue?.labels || []).map((l) => l?.name).filter(Boolean);
+  }
+
+  if (context.eventName === 'pull_request') {
+    return (context.payload?.pull_request?.labels || []).map((l) => l?.name).filter(Boolean);
+  }
+
+  return [];
+}
+
+function contentNodeIdFromContext({ context }) {
+  if (context.eventName === 'issues') return context.payload?.issue?.node_id || null;
+  if (context.eventName === 'pull_request') return context.payload?.pull_request?.node_id || null;
+  return null;
+}
+
+async function getProjectItemForContent({ graphql, projectNumber, contentNodeId }) {
+  const query = `
+    query($id: ID!) {
+      node(id: $id) {
+        __typename
+        ... on Issue {
+          url
+          projectItems(first: 50) {
+            nodes { id project { id number } }
+          }
+        }
+        ... on PullRequest {
+          url
+          projectItems(first: 50) {
+            nodes { id project { id number } }
+          }
+        }
+      }
+    }
+  `;
+
+  const res = await graphql(query, { id: contentNodeId });
+  const node = res?.node;
+  if (!node) return null;
+
+  const items = node?.projectItems?.nodes || [];
+  const item = items.find((it) => it?.project?.number === projectNumber);
+
+  return {
+    content: node,
+    itemId: item?.id || null,
+    projectId: item?.project?.id || null,
+  };
+}
+
+async function deleteProjectItem({ graphql, projectId, itemId }) {
+  const mutation = `
+    mutation($projectId: ID!, $itemId: ID!) {
+      deleteProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) {
+        deletedItemId
+      }
+    }
+  `;
+
+  const res = await graphql(mutation, { projectId, itemId });
+  return res?.deleteProjectV2Item?.deletedItemId || null;
+}
+
+async function cleanupOne({ graphql, core, projectNumber, contentNodeId, projectIdHint, retryAttempts, retryDelayMs }) {
+  for (let attempt = 1; attempt <= retryAttempts; attempt += 1) {
+    const itemRes = await getProjectItemForContent({ graphql, projectNumber, contentNodeId });
+    const { content, itemId, projectId } = itemRes || {};
+
+    if (itemId) {
+      const effectiveProjectId = projectIdHint || projectId;
+      if (!effectiveProjectId) {
+        throw new Error('Found Project itemId but no projectId available; cannot delete.');
+      }
+
+      const deleted = await deleteProjectItem({ graphql, projectId: effectiveProjectId, itemId });
+      core.info(`Removed from Project #${projectNumber}: ${content?.url || contentNodeId} (deletedItemId=${deleted || 'unknown'})`);
+      return { removed: true };
+    }
+
+    if (attempt < retryAttempts) {
+      core.info(
+        `Not in Project #${projectNumber} yet (attempt ${attempt}/${retryAttempts}); waiting ${retryDelayMs}ms to re-check…`
+      );
+      await sleep(retryDelayMs);
+      continue;
+    }
+
+    core.info(`Content is not in Project #${projectNumber}; nothing to do.`);
+    return { removed: false };
+  }
+
+  return { removed: false };
+}
+
+async function searchAutomationLabeledItems({ graphql, owner, repo, label, max = 50 }) {
+  const query = `repo:${owner}/${repo} label:"${label}"`;
+
+  const q = `
+    query($q: String!, $n: Int!) {
+      search(type: ISSUE, query: $q, first: $n) {
+        nodes {
+          __typename
+          ... on Issue { id url }
+          ... on PullRequest { id url }
+        }
+      }
+    }
+  `;
+
+  const res = await graphql(q, { q: query, n: max });
+  const nodes = res?.search?.nodes || [];
+  return nodes.filter((n) => n?.id);
+}
+
+async function cleanupAllAutomationItems({ github, context, core, env }) {
+  const label = env?.AUTOMATION_LABEL || 'automation';
+  const projectNumber = Number(env?.PROJECT_NUMBER || 1);
+  const { owner, repo } = context.repo;
+
+  const retryAttempts = Number(env?.RETRY_ATTEMPTS || DEFAULT_RETRY_ATTEMPTS);
+  const retryDelayMs = Number(env?.RETRY_DELAY_MS || DEFAULT_RETRY_DELAY_MS);
+
+  const graphql = github.graphql;
+
+  core.info(`Searching for items labeled '${label}' to remove from Project #${projectNumber}…`);
+  const nodes = await searchAutomationLabeledItems({ graphql, owner, repo, label, max: 50 });
+  core.info(`Found ${nodes.length} item(s) labeled '${label}'.`);
+
+  let removed = 0;
+  for (const node of nodes) {
+    const res = await cleanupOne({
+      graphql,
+      core,
+      projectNumber,
+      contentNodeId: node.id,
+      projectIdHint: null,
+      retryAttempts,
+      retryDelayMs,
+    });
+    if (res.removed) removed += 1;
+  }
+
+  core.info(`Cleanup complete. removed=${removed}/${nodes.length}`);
+}
+
+async function run({ github, context, core, env }) {
+  const automationLabel = env?.AUTOMATION_LABEL || 'automation';
+  const projectNumber = Number(env?.PROJECT_NUMBER || 1);
+
+  const retryAttempts = Number(env?.RETRY_ATTEMPTS || DEFAULT_RETRY_ATTEMPTS);
+  const retryDelayMs = Number(env?.RETRY_DELAY_MS || DEFAULT_RETRY_DELAY_MS);
+
+  const cleanupAll =
+    context.eventName === 'workflow_dispatch' &&
+    toBool(context.payload?.inputs?.cleanup_all, false);
+
+  if (cleanupAll) {
+    await cleanupAllAutomationItems({ github, context, core, env });
+    return;
+  }
+
+  const labels = labelsFromContext({ context }).map(normalize);
+  if (!labels.includes(normalize(automationLabel))) {
+    core.info(`No '${automationLabel}' label detected; nothing to do.`);
+    return;
+  }
+
+  const contentNodeId = contentNodeIdFromContext({ context });
+  if (!contentNodeId) {
+    core.info('No content node id found in event payload; nothing to do.');
+    return;
+  }
+
+  const graphql = github.graphql;
+
+  core.info(`Detected '${automationLabel}' label; ensuring item is not in Project #${projectNumber}…`);
+
+  await cleanupOne({
+    graphql,
+    core,
+    projectNumber,
+    contentNodeId,
+    projectIdHint: null,
+    retryAttempts,
+    retryDelayMs,
+  });
+}
+
+module.exports = {
+  run,
+};

--- a/.github/scripts/project-autoadd-exclude-automation.cjs
+++ b/.github/scripts/project-autoadd-exclude-automation.cjs
@@ -37,7 +37,18 @@ function contentNodeIdFromContext({ context }) {
   return null;
 }
 
-async function getProjectItemForContent({ graphql, projectNumber, contentNodeId }) {
+function projectOwnerLogin(project) {
+  return project?.owner?.login || null;
+}
+
+function projectMatchesTarget({ project, projectNumber, projectOwner }) {
+  return (
+    project?.number === projectNumber &&
+    normalize(projectOwnerLogin(project)) === normalize(projectOwner)
+  );
+}
+
+async function getProjectItemForContent({ graphql, projectNumber, projectOwner, contentNodeId, core }) {
   const query = `
     query($id: ID!) {
       node(id: $id) {
@@ -45,13 +56,13 @@ async function getProjectItemForContent({ graphql, projectNumber, contentNodeId 
         ... on Issue {
           url
           projectItems(first: 50) {
-            nodes { id project { id number } }
+            nodes { id project { id number owner { ... on Organization { login } ... on User { login } } } }
           }
         }
         ... on PullRequest {
           url
           projectItems(first: 50) {
-            nodes { id project { id number } }
+            nodes { id project { id number owner { ... on Organization { login } ... on User { login } } } }
           }
         }
       }
@@ -63,7 +74,14 @@ async function getProjectItemForContent({ graphql, projectNumber, contentNodeId 
   if (!node) return null;
 
   const items = node?.projectItems?.nodes || [];
-  const item = items.find((it) => it?.project?.number === projectNumber);
+  const item = items.find((it) => projectMatchesTarget({ project: it?.project, projectNumber, projectOwner }));
+  const wrongOwnerItem = items.find((it) => it?.project?.number === projectNumber && !projectMatchesTarget({ project: it?.project, projectNumber, projectOwner }));
+  if (!item && wrongOwnerItem && core?.warning) {
+    core.warning(
+      `Found Project #${projectNumber} item owned by '${projectOwnerLogin(wrongOwnerItem.project) || 'unknown'}'; ` +
+        `expected owner '${projectOwner}'. Skipping delete for safety.`
+    );
+  }
 
   return {
     content: node,
@@ -85,9 +103,9 @@ async function deleteProjectItem({ graphql, projectId, itemId }) {
   return res?.deleteProjectV2Item?.deletedItemId || null;
 }
 
-async function cleanupOne({ graphql, core, projectNumber, contentNodeId, projectIdHint, retryAttempts, retryDelayMs }) {
+async function cleanupOne({ graphql, core, projectNumber, projectOwner, contentNodeId, projectIdHint, retryAttempts, retryDelayMs }) {
   for (let attempt = 1; attempt <= retryAttempts; attempt += 1) {
-    const itemRes = await getProjectItemForContent({ graphql, projectNumber, contentNodeId });
+    const itemRes = await getProjectItemForContent({ graphql, projectNumber, projectOwner, contentNodeId, core });
     const { content, itemId, projectId } = itemRes || {};
 
     if (itemId) {
@@ -97,19 +115,19 @@ async function cleanupOne({ graphql, core, projectNumber, contentNodeId, project
       }
 
       const deleted = await deleteProjectItem({ graphql, projectId: effectiveProjectId, itemId });
-      core.info(`Removed from Project #${projectNumber}: ${content?.url || contentNodeId} (deletedItemId=${deleted || 'unknown'})`);
+      core.info(`Removed from ${projectOwner} Project #${projectNumber}: ${content?.url || contentNodeId} (deletedItemId=${deleted || 'unknown'})`);
       return { removed: true };
     }
 
     if (attempt < retryAttempts) {
       core.info(
-        `Not in Project #${projectNumber} yet (attempt ${attempt}/${retryAttempts}); waiting ${retryDelayMs}ms to re-check…`
+        `Not in ${projectOwner} Project #${projectNumber} yet (attempt ${attempt}/${retryAttempts}); waiting ${retryDelayMs}ms to re-check…`
       );
       await sleep(retryDelayMs);
       continue;
     }
 
-    core.info(`Content is not in Project #${projectNumber}; nothing to do.`);
+    core.info(`Content is not in ${projectOwner} Project #${projectNumber}; nothing to do.`);
     return { removed: false };
   }
 
@@ -139,14 +157,16 @@ async function searchAutomationLabeledItems({ graphql, owner, repo, label, max =
 async function cleanupAllAutomationItems({ github, context, core, env }) {
   const label = env?.AUTOMATION_LABEL || 'automation';
   const projectNumber = Number(env?.PROJECT_NUMBER || 1);
+  const projectOwner = env?.ORG_LOGIN || context.repo?.owner;
   const { owner, repo } = context.repo;
+  if (!projectOwner) throw new Error('ORG_LOGIN (project owner) is required before deleting Project items.');
 
   const retryAttempts = Number(env?.RETRY_ATTEMPTS || DEFAULT_RETRY_ATTEMPTS);
   const retryDelayMs = Number(env?.RETRY_DELAY_MS || DEFAULT_RETRY_DELAY_MS);
 
   const graphql = github.graphql;
 
-  core.info(`Searching for items labeled '${label}' to remove from Project #${projectNumber}…`);
+  core.info(`Searching for items labeled '${label}' to remove from ${projectOwner} Project #${projectNumber}…`);
   const nodes = await searchAutomationLabeledItems({ graphql, owner, repo, label, max: 50 });
   core.info(`Found ${nodes.length} item(s) labeled '${label}'.`);
 
@@ -156,6 +176,7 @@ async function cleanupAllAutomationItems({ github, context, core, env }) {
       graphql,
       core,
       projectNumber,
+      projectOwner,
       contentNodeId: node.id,
       projectIdHint: null,
       retryAttempts,
@@ -170,6 +191,8 @@ async function cleanupAllAutomationItems({ github, context, core, env }) {
 async function run({ github, context, core, env }) {
   const automationLabel = env?.AUTOMATION_LABEL || 'automation';
   const projectNumber = Number(env?.PROJECT_NUMBER || 1);
+  const projectOwner = env?.ORG_LOGIN || context.repo?.owner;
+  if (!projectOwner) throw new Error('ORG_LOGIN (project owner) is required before deleting Project items.');
 
   const retryAttempts = Number(env?.RETRY_ATTEMPTS || DEFAULT_RETRY_ATTEMPTS);
   const retryDelayMs = Number(env?.RETRY_DELAY_MS || DEFAULT_RETRY_DELAY_MS);
@@ -197,12 +220,13 @@ async function run({ github, context, core, env }) {
 
   const graphql = github.graphql;
 
-  core.info(`Detected '${automationLabel}' label; ensuring item is not in Project #${projectNumber}…`);
+  core.info(`Detected '${automationLabel}' label; ensuring item is not in ${projectOwner} Project #${projectNumber}…`);
 
   await cleanupOne({
     graphql,
     core,
     projectNumber,
+    projectOwner,
     contentNodeId,
     projectIdHint: null,
     retryAttempts,
@@ -212,4 +236,6 @@ async function run({ github, context, core, env }) {
 
 module.exports = {
   run,
+  getProjectItemForContent,
+  projectMatchesTarget,
 };

--- a/.github/workflows/project-autoadd-exclude-automation.yml
+++ b/.github/workflows/project-autoadd-exclude-automation.yml
@@ -35,8 +35,8 @@ jobs:
     # Reduce workflow noise: only run for items labeled `automation` (or on manual dispatch).
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, env.AUTOMATION_LABEL)) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, env.AUTOMATION_LABEL))
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'automation')) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'automation'))
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/project-autoadd-exclude-automation.yml
+++ b/.github/workflows/project-autoadd-exclude-automation.yml
@@ -1,0 +1,97 @@
+name: Exclude automation items from Project #1
+
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request:
+    types: [opened, labeled]
+  workflow_dispatch:
+    inputs:
+      cleanup_all:
+        description: 'If true, search repo for items labeled automation and remove them from Project #1'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: project-autoadd-exclude-automation
+  cancel-in-progress: false
+
+jobs:
+  exclude:
+    runs-on: ubuntu-latest
+    env:
+      ORG_LOGIN: Clay-Agency
+      PROJECT_NUMBER: '1'
+      AUTOMATION_LABEL: automation
+      # Backstop for eventual consistency / workflow order: Project auto-add may run slightly after issue creation.
+      RETRY_ATTEMPTS: '6'
+      RETRY_DELAY_MS: '10000'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve Projects v2 auth configuration
+        id: auth
+        shell: bash
+        env:
+          PROJECTS_APP_ID: ${{ vars.PROJECTS_APP_ID || secrets.PROJECTS_APP_ID }}
+          PROJECTS_APP_PRIVATE_KEY: ${{ secrets.PROJECTS_APP_PRIVATE_KEY }}
+          PROJECT_STATUS_SYNC_TOKEN: ${{ secrets.PROJECT_STATUS_SYNC_TOKEN }}
+        run: node .github/scripts/resolve-projects-auth.cjs
+
+      - name: Create GitHub App token (preferred)
+        id: app-token
+        if: ${{ steps.auth.outputs.use_app == 'true' }}
+        uses: actions/create-github-app-token@v2
+        continue-on-error: true
+        with:
+          app-id: ${{ steps.auth.outputs.app_id }}
+          private-key: ${{ secrets.PROJECTS_APP_PRIVATE_KEY }}
+          owner: ${{ env.ORG_LOGIN }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Select Projects v2 token (App > PAT)
+        id: token
+        shell: bash
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          PAT_TOKEN: ${{ secrets.PROJECT_STATUS_SYNC_TOKEN }}
+        run: node .github/scripts/select-projects-token.cjs
+
+      - name: Skip fast (missing Projects v2 auth)
+        if: ${{ steps.token.outputs.token == '' }}
+        shell: bash
+        env:
+          VARS_PROJECTS_APP_ID: ${{ vars.PROJECTS_APP_ID }}
+          SECRETS_PROJECTS_APP_ID: ${{ secrets.PROJECTS_APP_ID }}
+          PROJECTS_APP_PRIVATE_KEY: ${{ secrets.PROJECTS_APP_PRIVATE_KEY }}
+          PROJECT_STATUS_SYNC_TOKEN: ${{ secrets.PROJECT_STATUS_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          docs_url="https://github.com/${GITHUB_REPOSITORY}/blob/main/docs/ops/projects-v2-auth-runbook.md"
+
+          append() { printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"; }
+
+          append "# Project auto-add exclusion — skipped (Projects v2 auth missing)"
+          append ""
+          append "Runbook: ${docs_url}"
+
+          echo "::warning title=No Projects v2 auth token available::Skipping Project auto-add exclusion because no Projects v2 auth token is configured. Configure Projects v2 auth: GitHub App (preferred) set vars.PROJECTS_APP_ID + secrets.PROJECTS_APP_PRIVATE_KEY, OR PAT set secrets.PROJECT_STATUS_SYNC_TOKEN. Runbook: ${docs_url}"
+          exit 0
+
+      - name: Remove automation-labeled items from Project #1 (backstop)
+        uses: actions/github-script@v7
+        if: ${{ steps.token.outputs.token != '' }}
+        with:
+          github-token: ${{ steps.token.outputs.token }}
+          script: |
+            const { run } = require('./.github/scripts/project-autoadd-exclude-automation.cjs');
+            await run({ github, context, core, env: process.env });

--- a/.github/workflows/project-autoadd-exclude-automation.yml
+++ b/.github/workflows/project-autoadd-exclude-automation.yml
@@ -22,16 +22,22 @@ concurrency:
   group: project-autoadd-exclude-automation
   cancel-in-progress: false
 
+env:
+  ORG_LOGIN: Clay-Agency
+  PROJECT_NUMBER: '1'
+  AUTOMATION_LABEL: automation
+  # Backstop for eventual consistency / workflow order: Project auto-add may run slightly after issue creation.
+  RETRY_ATTEMPTS: '6'
+  RETRY_DELAY_MS: '10000'
+
 jobs:
   exclude:
+    # Reduce workflow noise: only run for items labeled `automation` (or on manual dispatch).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, env.AUTOMATION_LABEL)) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, env.AUTOMATION_LABEL))
     runs-on: ubuntu-latest
-    env:
-      ORG_LOGIN: Clay-Agency
-      PROJECT_NUMBER: '1'
-      AUTOMATION_LABEL: automation
-      # Backstop for eventual consistency / workflow order: Project auto-add may run slightly after issue creation.
-      RETRY_ATTEMPTS: '6'
-      RETRY_DELAY_MS: '10000'
 
     steps:
       - name: Checkout

--- a/docs/ops/project-1-workflow-auto-add-filter.md
+++ b/docs/ops/project-1-workflow-auto-add-filter.md
@@ -5,6 +5,12 @@ Use this when Project #1 is auto-adding “meta”/automation issues (for contex
 ## Goal
 Update the Project #1 **Workflows → Auto-add** filter to exclude issues labeled `automation` by appending `-label:automation`.
 
+## Repo backstop (GitHub Actions)
+This repo includes a small backstop workflow that will **remove any issue/PR labeled `automation` from Project #1** if it gets auto-added anyway:
+- Workflow: `.github/workflows/project-autoadd-exclude-automation.yml`
+
+This is intentionally lightweight and should not replace the **Project Workflows → Auto-add filter**. Keep the filter updated so automation items never enter the project in the first place.
+
 ### Example filter
 Use this exact filter (minimum viable):
 

--- a/src/ops/projectAutoaddExcludeAutomation.test.ts
+++ b/src/ops/projectAutoaddExcludeAutomation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { getProjectItemForContent, projectMatchesTarget } = require('../../.github/scripts/project-autoadd-exclude-automation.cjs');
+
+describe('project-autoadd-exclude-automation', () => {
+  it('matches Project items by number and owner login', () => {
+    expect(
+      projectMatchesTarget({
+        project: { number: 1, owner: { login: 'Clay-Agency' } },
+        projectNumber: 1,
+        projectOwner: 'clay-agency',
+      })
+    ).toBe(true);
+
+    expect(
+      projectMatchesTarget({
+        project: { number: 1, owner: { login: 'someone-else' } },
+        projectNumber: 1,
+        projectOwner: 'Clay-Agency',
+      })
+    ).toBe(false);
+  });
+
+  it('returns only the target owner Project item when another owner has the same project number', async () => {
+    const graphql = vi.fn(async () => ({
+      node: {
+        url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/212',
+        projectItems: {
+          nodes: [
+            { id: 'ITEM_OTHER', project: { id: 'PROJ_OTHER', number: 1, owner: { login: 'someone-else' } } },
+            { id: 'ITEM_TARGET', project: { id: 'PROJ_TARGET', number: 1, owner: { login: 'Clay-Agency' } } },
+          ],
+        },
+      },
+    }));
+
+    const res = await getProjectItemForContent({
+      graphql,
+      projectNumber: 1,
+      projectOwner: 'Clay-Agency',
+      contentNodeId: 'CONTENT',
+      core: { warning: vi.fn() },
+    });
+
+    expect(res.itemId).toBe('ITEM_TARGET');
+    expect(res.projectId).toBe('PROJ_TARGET');
+  });
+
+  it('skips and warns when the only same-number Project item has the wrong owner', async () => {
+    const warning = vi.fn();
+    const graphql = vi.fn(async () => ({
+      node: {
+        url: 'https://github.com/other/repo/issues/1',
+        projectItems: {
+          nodes: [
+            { id: 'ITEM_OTHER', project: { id: 'PROJ_OTHER', number: 1, owner: { login: 'someone-else' } } },
+          ],
+        },
+      },
+    }));
+
+    const res = await getProjectItemForContent({
+      graphql,
+      projectNumber: 1,
+      projectOwner: 'Clay-Agency',
+      contentNodeId: 'CONTENT',
+      core: { warning },
+    });
+
+    expect(res.itemId).toBeNull();
+    expect(res.projectId).toBeNull();
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("expected owner 'Clay-Agency'"));
+  });
+});


### PR DESCRIPTION
Closes #212

## What
- Adds a small GitHub Actions backstop that removes any issue/PR labeled `automation` from Clay-Agency Project #1 if it gets auto-added anyway.
- Documents the backstop in `docs/ops/project-1-workflow-auto-add-filter.md`.

## Why
Project #1 auto-add is occasionally pulling in automation/meta issues (e.g., needs-decision snapshot). The Project UI filter (`-label:automation`) is still the primary control, but this workflow provides defense-in-depth.

## How
- New workflow: `.github/workflows/project-autoadd-exclude-automation.yml` (issues/PR opened+labeled + manual `cleanup_all`)
- New script: `.github/scripts/project-autoadd-exclude-automation.cjs`

## Self-review
- [x] xhigh
- [x] No changes to unrelated automation
- [x] Workflow YAML parses (`npm run check:workflows`)
