### PR TITLE
docs: add standard decision-brief template for Project #1 issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ If an issue/PR is blocked on an **explicit decision from Clay**, apply the repo 
 
 Optional (if you’re using the Project #1 board): also set the Project field `Needs decision: True`.
 
+When preparing a live decision handoff in an existing issue/PR, use the compact [`docs/ops/decision-brief-template.md`](./docs/ops/decision-brief-template.md) so Clay gets the same structure each time (decision needed, recommendation, options, risks, blocked work, deadline, exact ask, evidence).
+
 Canonical snapshot (updated daily): the single issue titled `Needs-decision snapshot (automated)`
 - Find it: https://github.com/Clay-Agency/novel-task-tracker/issues?q=is%3Aissue+is%3Aopen+%22Needs-decision+snapshot+%28automated%29%22
 - Run manually: https://github.com/Clay-Agency/novel-task-tracker/actions/workflows/needs-decision-snapshot.yml (Actions → "Needs-decision daily snapshot" → Run workflow)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Quick filter: [`label:needs-decision`](https://github.com/Clay-Agency/novel-task
 Use the `needs-decision` label when an issue/PR is blocked on an **explicit decision from Clay**.
 
 - Apply/remove guidelines: [`CONTRIBUTING.md#needs-decision-convention`](./CONTRIBUTING.md#needs-decision-convention)
+- Standard decision-brief comment template for active Project #1 items: [`docs/ops/decision-brief-template.md`](./docs/ops/decision-brief-template.md)
 - Canonical daily snapshot issue (automation overwrites the body): search for [`Needs-decision snapshot (automated)`](https://github.com/Clay-Agency/novel-task-tracker/issues?q=is%3Aissue+is%3Aopen+%22Needs-decision+snapshot+%28automated%29%22)
 - Run snapshot manually: [Actions → “Needs-decision daily snapshot”](https://github.com/Clay-Agency/novel-task-tracker/actions/workflows/needs-decision-snapshot.yml) → **Run workflow** (no Projects v2 auth required)
 

--- a/docs/ops/decision-brief-template.md
+++ b/docs/ops/decision-brief-template.md
@@ -1,0 +1,70 @@
+# Standard decision-brief template (Project #1)
+
+Use this template when a Project #1 issue/PR is **waiting on an explicit Clay decision** and Boe/May needs to prepare a compact, repeatable brief in an issue comment or doc.
+
+This is the **middle artifact** between:
+- opening a new decision issue (`.github/ISSUE_TEMPLATE/decision-request.yml`), and
+- writing the final decision record after the choice is made (`docs/decisions/decision-record-template.md`).
+
+## When to use
+
+Use a decision brief when:
+- the work is already tracked in an existing issue/PR,
+- the next step is blocked on a decision, and
+- Clay needs a short, high-signal packet rather than a long thread.
+
+If the decision does **not** already have an issue, start with the repo's **Decision request** issue template first.
+
+## Standard template
+
+Copy/paste into an issue comment and fill in the blanks:
+
+```md
+### Decision brief — <short topic>
+
+**Decision needed:** <the exact choice Clay needs to make>
+
+**Recommendation:** <preferred option>
+<1-2 sentence rationale>
+
+#### Option A — <name>
+- Pros: <bullets>
+- Cons: <bullets>
+
+#### Option B — <name>
+- Pros: <bullets>
+- Cons: <bullets>
+
+<!-- Optional: include only if there is a realistic third option -->
+#### Option C — <name>
+- Pros: <bullets>
+- Cons: <bullets>
+
+**Risks / tradeoffs:**
+- <risk or second-order effect>
+- <risk or second-order effect>
+
+**Blocked work if unanswered:**
+- <issue/PR/task that remains blocked>
+
+**Deadline / urgency:** <date, event, or 'No hard deadline; blocks next triage pass'>
+
+**Exact ask to Clay:** <pick A/B/C, approve recommendation, or provide another constraint>
+
+**Evidence:**
+- <issue / PR / doc / workflow link>
+- <issue / PR / doc / workflow link>
+```
+
+## Writing guidance
+
+- Keep it **compact**: usually 8-20 lines, not an essay.
+- Prefer **1-2 realistic options**; use 3 only when necessary.
+- Put the **recommendation near the top** so Clay can decide quickly.
+- Make the **exact ask** explicit so the thread ends with a clear action.
+- Link only the **minimum evidence** needed to justify the recommendation.
+
+## Example in this repo
+
+- #126 Priority taxonomy — example decision brief comment:
+  https://github.com/Clay-Agency/novel-task-tracker/issues/126#issuecomment-4019857596

--- a/docs/ops/open-decisions.md
+++ b/docs/ops/open-decisions.md
@@ -2,6 +2,8 @@
 
 This page is a lightweight checklist of decisions that block ops/automation work.
 
+Use the standard comment format in [`docs/ops/decision-brief-template.md`](./decision-brief-template.md) when posting or updating a decision brief on one of these issues.
+
 ## Decisions
 
 - [ ] **#80 Projects v2 auth for Project #1 automation** — decide **GitHub App vs PAT** for Actions to update Project fields.
@@ -11,4 +13,4 @@ This page is a lightweight checklist of decisions that block ops/automation work
 
 - [ ] **#126 Priority taxonomy (P0–P3 vs P0–P2)** — decide whether to **add P3** to Project #1 (or collapse P3 into P2).
   - Issue: https://github.com/Clay-Agency/novel-task-tracker/issues/126
-  - Decision memo comment: https://github.com/Clay-Agency/novel-task-tracker/issues/126#issuecomment-3993404482
+  - Example decision brief comment: https://github.com/Clay-Agency/novel-task-tracker/issues/126#issuecomment-4019857596

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -52,6 +52,7 @@ Conventions:
   - 1–3 options
   - (optional) a recommended default
   - links/evidence (can also be mirrored into the project `Evidence` field)
+- For repeatable issue updates/comments, use [`docs/ops/decision-brief-template.md`](./decision-brief-template.md).
 - Set back to **False** once the decision is made or no longer blocks progress.
 
 ## Evidence (text)


### PR DESCRIPTION
## Summary
- add a reusable `docs/ops/decision-brief-template.md` for active Project #1 `needs-decision` issue updates
- link the template from existing process docs (`README`, `CONTRIBUTING`, field conventions, open decisions)
- add a live example decision-brief comment on #126 and reference it from `docs/ops/open-decisions.md`

## Testing
- docs-only change; verified internal file references by inspection

Closes #215
