### PR TITLE
chore: add lightweight docs verify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,14 @@ npm run start
 
 ## Quality checks
 ```bash
+npm run verify:docs
 npm run lint
 npm run typecheck
 npm run test
 npm run e2e
 ```
+
+`npm run verify:docs` runs the lightweight docs gate: workflow YAML validation plus repo-internal Markdown link checks.
 
 ## Build
 ```bash

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check:workflows": "ruby -e 'require \"yaml\"; Dir[\".github/workflows/*.{yml,yaml}\"].sort.each { |f| YAML.load_file(f); puts \"OK #{f}\" }'",
     "docs:links": "node scripts/check-doc-links.js README.md docs",
     "docs:links:docker": "docker run --rm -v \"$PWD\":/workdir -w /workdir ghcr.io/lycheeverse/lychee:latest --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
+    "verify:docs": "npm run check:workflows && npm run docs:links",
     "verify:quick": "npm run check:workflows && npm run lint && npm run typecheck && npm test",
     "verify:core": "npm run verify:quick && npm run build"
   },


### PR DESCRIPTION
Closes #218

## Summary
- add `npm run verify:docs` as a lightweight docs/ops verification command
- document the command in `README.md`
- keep the existing full app verification flow unchanged

## Validation
- `npm run verify:docs`

## Notes
- stacked on top of #235 because `verify:docs` depends on the repo-local docs link checker introduced there