### PR TITLE
docs: expose verify:quick and verify:core in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,17 @@ npm run start
 ```
 
 ## Quality checks
+Use the fast verification commands below for local changes:
+
 ```bash
-npm run lint
-npm run typecheck
-npm run test
+npm run verify:quick
+npm run verify:core
 npm run e2e
 ```
+
+- `verify:quick`: workflows check + lint + typecheck + tests
+- `verify:core`: `verify:quick` plus a production build
+- For docs-only updates, start with `npm run docs:links`.
 
 ## Build
 ```bash


### PR DESCRIPTION
## Summary
- replace the generic README quality-check list with the dedicated `verify:quick` and `verify:core` commands
- add one-line explanations so contributors can choose the right local gate
- keep docs-only guidance for `npm run docs:links` in the same section

## Testing
- `npm run docs:links` *(fails in this environment: `lychee` is not installed)*