### PR TITLE
chore: add local pre-PR verification command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,17 @@ npm run start
 ```
 
 ## Quality checks
+Use `npm run verify:local` as the standard local pre-PR command. It runs Markdown link checks plus the default app verification path without the slower Playwright suite.
+
 ```bash
-npm run lint
-npm run typecheck
-npm run test
+npm run verify:local
+npm run verify:quick
+npm run verify:core
 npm run e2e
 ```
+
+`verify:local` expands to `npm run docs:links && npm run verify:quick`.
+For docs-only updates, you can still start with `npm run docs:links`.
 
 ## Build
 ```bash

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "docs:links": "lychee --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
     "docs:links:docker": "docker run --rm -v \"$PWD\":/workdir -w /workdir ghcr.io/lycheeverse/lychee:latest --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
     "verify:quick": "npm run check:workflows && npm run lint && npm run typecheck && npm test",
+    "verify:local": "npm run docs:links && npm run verify:quick",
     "verify:core": "npm run verify:quick && npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #219

## Summary
- add `npm run verify:local` as a single local pre-PR command
- compose the existing docs link check with `verify:quick`
- document the new command in `README.md`

## Validation
- `npm run verify:quick` ✅
- `npm run verify:local` ⚠️ blocked locally because `lychee` is not installed in this environment
  - existing fallback `npm run docs:links:docker` also could not run here because the Docker daemon was unavailable

## Notes
- `verify:local` intentionally excludes the slower Playwright suite and keeps `npm run e2e` separate
- no product code changes
