### PR TITLE
dx: add clean setup npm script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,11 @@ nvm use
 
 (`.nvmrc` is set to `20`.)
 
+## Install command guidance
+
+- Use `npm run setup:clean` on a fresh checkout when you want a discoverable, lockfile-faithful, CI-aligned install (`npm ci` under the hood).
+- Use `npm install` only when you intentionally add/update dependencies.
+
 ## Branch + PR flow
 
 1. Branch from `main` with `feat/issue-<number>-<summary>`.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Checklist: [`docs/ops/open-decisions.md`](./docs/ops/open-decisions.md)
 - npm 9+
 
 ## Setup
+For the cleanest CI-aligned install on a fresh checkout, prefer:
+```bash
+npm run setup:clean
+```
+
+That script wraps:
+```bash
+npm ci
+```
+
+If you intentionally changed dependencies, use:
 ```bash
 npm install
 ```

--- a/docs/qa/pilot-readiness-cross-browser-plan.md
+++ b/docs/qa/pilot-readiness-cross-browser-plan.md
@@ -38,7 +38,7 @@ Validate all checklist items on at least the following matrix before pilot sign-
 ## 3) Pre-QA Setup
 
 1. Pull latest `main` and run:
-   - `npm install`
+   - `npm run setup:clean` (preferred for a clean, lockfile-faithful checkout)
    - `npm run dev`
 2. Use a fresh profile/incognito window (to avoid stale localStorage noise).
 3. Prepare seed tasks with mixed metadata:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "setup:clean": "npm ci",
     "dev": "vite",
     "start": "vite",
     "build": "vite build",


### PR DESCRIPTION
Closes #229

## Summary
- add `npm run setup:clean` as a discoverable wrapper around `npm ci`
- update README setup guidance to prefer the new clean-setup command on fresh checkouts
- document the same guidance in CONTRIBUTING and the QA preflight doc

## Verification
- `node -e "const p=require('./package.json'); console.log(p.scripts['setup:clean'])"`
- `npm run setup:clean`
- `npm run verify:core`

## Notes
- UI changes: N/A
- Risks: low; this is a script alias plus docs guidance only
