### PR TITLE
docs: align README Node prerequisite with CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,26 @@ Use the `needs-decision` label when an issue/PR is blocked on an **explicit deci
 Checklist: [`docs/ops/open-decisions.md`](./docs/ops/open-decisions.md)
 
 ## Prerequisites
-- Node.js 18+
+- Node.js 20+
 - npm 9+
 
+To match CI and the repo's pinned runtime, run:
+```bash
+nvm use
+```
+
 ## Setup
+For the cleanest CI-aligned install on a fresh checkout, prefer:
+```bash
+npm run setup:clean
+```
+
+That script wraps:
+```bash
+npm ci
+```
+
+If you intentionally changed dependencies, use:
 ```bash
 npm install
 ```


### PR DESCRIPTION
## Summary\n- update the README prerequisite from Node.js 18+ to Node.js 20+\n- point contributors to `nvm use` so local setup matches CI and \.nvmrc\n- clarify the preferred clean install path with `npm run setup:clean` / `npm ci`\n\nCloses #224\n\n## Validation\n- `git diff --check`\n- attempted `npm run docs:links` *(blocked: local `lychee` not installed in this environment)*\n- attempted `npm run docs:links:docker` *(blocked: Docker daemon unavailable in this environment)*