### PR TITLE
docs: link CONTRIBUTING verification to command matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,8 @@ npm run verify:quick
 npm run verify:core
 ```
 
+Need a different command for docs-only, workflows-only, or targeted checks? See the [local verification command matrix](./docs/testing/local-verification.md).
+
 
 ## 2-stage review process (required)
 

--- a/docs/testing/local-verification.md
+++ b/docs/testing/local-verification.md
@@ -1,0 +1,29 @@
+# Local Verification Command Matrix
+
+Use this matrix to pick the smallest command that matches your change before opening a PR.
+
+## Command matrix
+
+| Situation | Command | Includes |
+| --- | --- | --- |
+| Quick inner-loop check before pushing | `npm run verify:quick` | workflow YAML parse, lint, typecheck, unit/integration tests |
+| Full pre-merge verification | `npm run verify:core` | everything in `verify:quick` plus production build |
+| Docs-only link validation | `npm run docs:links` | internal/relative link checks for `README.md` and `docs/**` |
+| Docs-only link validation without local `lychee` install | `npm run docs:links:docker` | same link checks using Docker |
+| Workflow-only changes | `npm run check:workflows` | parses `.github/workflows/*.{yml,yaml}` |
+| Code quality only | `npm run lint` | ESLint with `--max-warnings 0` |
+| Type safety only | `npm run typecheck` | TypeScript compile check without emit |
+| Unit + UI integration tests only | `npm test` | Vitest suite |
+| Production build only | `npm run build` | Vite production build |
+| End-to-end browser checks | `npm run e2e` | Playwright end-to-end tests |
+
+## Recommended defaults
+
+- **Docs-only changes:** run `npm run docs:links`
+- **Typical code changes during development:** run `npm run verify:quick`
+- **Before final review / merge:** run `npm run verify:core`
+
+## Related docs
+
+- [Contributing guide](../../CONTRIBUTING.md)
+- [Core test strategy](./core-test-strategy.md)


### PR DESCRIPTION
## Summary
- add `docs/testing/local-verification.md` as a small command matrix for local verification
- link the `CONTRIBUTING.md` verification section to that matrix so contributors can choose the right command without searching
- keep scope limited to docs navigation for issue #225

Closes #225

## Verification
- lightweight fallback check: confirmed the new relative links resolve locally
- `npm run docs:links` could not run in this environment because `lychee` is not installed
- `npm run docs:links:docker` could not run in this environment because the Docker daemon is not running
