### PR TITLE
docs(dx): prefer npm ci for clean local setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,11 @@ nvm use
 
 (`.nvmrc` is set to `20`.)
 
+## Install command guidance
+
+- Use `npm ci` on a fresh checkout when you want lockfile-faithful, CI-aligned installs.
+- Use `npm install` only when you intentionally add/update dependencies.
+
 ## Branch + PR flow
 
 1. Branch from `main` with `feat/issue-<number>-<summary>`.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Checklist: [`docs/ops/open-decisions.md`](./docs/ops/open-decisions.md)
 - npm 9+
 
 ## Setup
+For the cleanest CI-aligned install on a fresh checkout, prefer:
+```bash
+npm ci
+```
+
+If you intentionally changed dependencies, use:
 ```bash
 npm install
 ```


### PR DESCRIPTION
Closes #227

## Summary
- prefer `npm ci` in README setup guidance for fresh local checkouts
- clarify that `npm install` is for intentional dependency changes
- add the same install-command guidance to CONTRIBUTING

## Verification
- `npm run verify:quick` ✅
- `npm run docs:links` ⚠️ failed locally because `lychee` is not installed in this environment (`sh: lychee: command not found`)
- `npm run verify:docs` ⚠️ referenced in issue evidence, but the script does not exist on current `main`
