### PR TITLE
docs(qa): prefer npm ci in pre-QA setup

### DIFF
--- a/docs/qa/pilot-readiness-cross-browser-plan.md
+++ b/docs/qa/pilot-readiness-cross-browser-plan.md
@@ -38,7 +38,7 @@ Validate all checklist items on at least the following matrix before pilot sign-
 ## 3) Pre-QA Setup
 
 1. Pull latest `main` and run:
-   - `npm install`
+   - `npm ci`
    - `npm run dev`
 2. Use a fresh profile/incognito window (to avoid stale localStorage noise).
 3. Prepare seed tasks with mixed metadata:


### PR DESCRIPTION
## Summary
- update the pre-QA setup steps to prefer `npm ci` for clean, lockfile-faithful installs
- keep the change scoped to the QA checklist doc referenced by issue #228

## Testing
- `git diff --check`
- `sed -n '38,45p' docs/qa/pilot-readiness-cross-browser-plan.md`
- attempted `npm run docs:links` *(blocked locally: `lychee` not installed in this environment)*
- attempted `npm run verify:docs` *(script does not exist in this repo)*

Closes #228