### PR TITLE
docs: align verification command references

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -23,7 +23,7 @@ List alternatives or why current behavior is insufficient.
 Any constraints, dependencies, or non-goals.
 
 ## QA / validation notes
-Reference relevant checklist docs/sections in `docs/qa/` if this request introduces UI/behavior that should be covered.
+Reference relevant checklist docs/sections in `docs/qa/` if this request introduces UI/behavior that should be covered. When proposing repo-supported local verification commands, use the canonical list in `CONTRIBUTING.md#canonical-local-verification-commands` (for docs-only work, that means `npm run docs:links`, not `npm run verify:docs`).
 
 ## Success criteria
 How will we know this request is done?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,21 +13,24 @@
 - [ ] Final review requested from **Boe**.
 
 ## Validation evidence
-### Lint
+### Required pre-merge verification
 ```bash
 # paste command + output
+npm run verify:core
+```
+
+### Docs-only validation (required when README.md, docs/**, or docs-facing templates change)
+```bash
+# paste command + output
+npm run docs:links
+```
+
+### Optional targeted command outputs
+```bash
+# paste command + output when useful
 npm run lint
-```
-
-### Tests
-```bash
-# paste command + output
+npm run typecheck
 npm test
-```
-
-### Build
-```bash
-# paste command + output
 npm run build
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,11 +87,17 @@ npm run docs:links:docker
 ```
 
 
-## Local verification commands
+## Canonical local verification commands
 
-Use the quick check during development, and full check before final review:
+Use the commands below as the **canonical local validation entry points** for this repo.
+If you are writing docs/issues/PRs, reference these exact commands rather than inventing aliases such as `npm run verify:docs`.
 
 ```bash
+# Docs-only validation for README.md + docs/** internal links
+npm run docs:links
+# or, if lychee is not installed locally:
+npm run docs:links:docker
+
 # Fast inner-loop verification (no build)
 npm run verify:quick
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,21 @@ npm run start
 ```
 
 ## Quality checks
+Canonical local validation commands live in [`CONTRIBUTING.md#canonical-local-verification-commands`](./CONTRIBUTING.md#canonical-local-verification-commands).
+
+Common entry points:
+
 ```bash
+# Docs-only validation for README.md + docs/** internal links
+npm run docs:links
+
+# Fast inner-loop verification (no build)
+npm run verify:quick
+
+# Full pre-merge verification (includes build)
+npm run verify:core
+
+# Targeted checks when you need them individually
 npm run lint
 npm run typecheck
 npm run test


### PR DESCRIPTION
## Summary
- centralize the canonical local validation entry points in `CONTRIBUTING.md`
- point `README.md` quality-check guidance at that canonical section and include the supported docs/quick/core commands
- update the PR template and feature-request template to steer docs/process work toward `npm run docs:links` instead of an invented `npm run verify:docs`

## Linked Issue
- Closes #250

## 2-stage review confirmation
### Stage 1 — Self-review (author, xhigh reasoning)
- [x] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).
- [x] I confirmed the implementation satisfies the linked issue scope.

### Stage 2 — Final review (Boe)
- [ ] Final review requested from **Boe**.

## Validation evidence
### Required pre-merge verification
```bash
Not run in full; this change is docs/templates only.
```

### Docs-only validation (required when README.md, docs/**, or docs-facing templates change)
```bash
npm run docs:links
sh: lychee: command not found

npm run docs:links:docker
Cannot connect to the Docker daemon at unix:///Users/syong/.orbstack/run/docker.sock. Is the docker daemon running?
```

### Optional targeted command outputs
```bash
git diff --check
# clean

python3 content assertions
# content checks passed
```

## UI changes
- [x] N/A (no UI changes)

## Risks / edge cases
- This intentionally documents `npm run verify:docs` only as a stale alias to avoid; if a future wrapper script is added, docs should be updated again.
- Docs-link verification still needs a normal environment with `lychee` installed or Docker running.

## Additional notes
- I did not find any live checked-in `verify:docs` command references before the edit; this PR prevents the mismatch from reappearing by making the supported commands more explicit and centralized.
