### PR TITLE
docs: define canonical docs-only validation path

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,21 +13,30 @@
 - [ ] Final review requested from **Boe**.
 
 ## Validation evidence
-### Lint
+### Required pre-merge verification
 ```bash
 # paste command + output
+npm run verify:core
+```
+
+### Docs-only validation (required when README.md, docs/**, or docs-facing templates change)
+```bash
+# paste command + output
+npm run docs:links
+
+# or, if local lychee is unavailable:
+npm run docs:links:docker
+
+# if neither local lychee nor Docker is available, explain that here
+# and note that the required CI workflow "Markdown link check" is expected to catch docs-link regressions.
+```
+
+### Optional targeted command outputs
+```bash
+# paste command + output when useful
 npm run lint
-```
-
-### Tests
-```bash
-# paste command + output
+npm run typecheck
 npm test
-```
-
-### Build
-```bash
-# paste command + output
 npm run build
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,47 +58,53 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 - [Projects v2 auth runbook](./docs/ops/projects-v2-auth-runbook.md): Use when configuring or debugging GitHub Actions auth for workflows that read/update the Clay-Agency org Project #1 (GraphQL `ProjectV2`).
 - [Project #1 field conventions](./docs/ops/project-1-field-conventions.md): Use when triaging work on the Project #1 board or building automation that writes project fields (Status, Priority, Owner agent, Needs decision, Evidence).
 
-## Markdown link check
+## Canonical docs-only validation path
 
 CI validates **internal/relative** links in `README.md` and `docs/**` (external URLs are intentionally skipped to avoid flaky failures).
 
-Run locally:
+When your change is docs-only or touches `README.md`, `docs/**`, or docs-facing templates, use this fallback order:
+
+1. Preferred: run `npm run docs:links` if local `lychee` is installed.
+2. If `lychee` is unavailable locally: run `npm run docs:links:docker`.
+3. If neither local `lychee` nor Docker is available: do **not** invent another docs alias. Note in the PR that the docs link check could not be run locally, and rely on the required CI workflow **Markdown link check** to catch link regressions.
+
+Important: `npm run verify:core` is useful for broader pre-merge validation, but it does **not** run the Markdown link checker and is **not** a substitute for `npm run docs:links` / `npm run docs:links:docker` when docs links changed.
 
 ```bash
-# Option A: run via npm (requires lychee installed)
+# Preferred: local lychee installed
 #   brew install lychee
 #   # or: cargo install lychee
-
 npm run docs:links
 
-# Option B: Docker (no local lychee install required)
+# Fallback: no local lychee, but Docker/OrbStack is available
 #   Optional readiness check (daemon reachable):
 #   docker info >/dev/null
-
 npm run docs:links:docker
 
-# (Equivalent direct command)
-# docker run --rm -v "$(pwd)":/workdir -w /workdir \
+# Equivalent direct Docker command
+# docker run --rm -v "$PWD":/workdir -w /workdir \
 #   ghcr.io/lycheeverse/lychee:latest \
 #   --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
-
-# If you see "Cannot connect to the Docker daemon", start Docker/OrbStack first,
-# then rerun the command.
 ```
 
+If Docker reports `Cannot connect to the Docker daemon`, start Docker/OrbStack first and rerun `npm run docs:links:docker`.
 
-## Local verification commands
+## Canonical local verification commands
 
-Use the quick check during development, and full check before final review:
+Use the commands below as the canonical local validation entry points for this repo. Reference these exact commands in issues/PRs instead of inventing aliases such as `npm run verify:docs`.
 
 ```bash
+# Docs-only validation for README.md + docs/** internal links
+npm run docs:links
+# or, if local lychee is unavailable:
+npm run docs:links:docker
+
 # Fast inner-loop verification (no build)
 npm run verify:quick
 
 # Full pre-merge verification (includes build)
 npm run verify:core
 ```
-
 
 ## 2-stage review process (required)
 
@@ -122,6 +128,7 @@ After Stage 1 is complete, request final review from **Boe**.
 - [ ] Linked issue(s) included (`Closes #...`)
 - [ ] Stage 1 self-review complete (xhigh reasoning applied)
 - [ ] `npm run verify:core` result attached
+- [ ] Docs-only validation evidence attached when README.md, `docs/**`, or docs-facing templates changed (`npm run docs:links` or `npm run docs:links:docker`; otherwise explain why CI covered it)
 - [ ] (optional) individual command outputs attached when needed (`check:workflows`, `lint`, `typecheck`, `test`, `build`)
 - [ ] UI change evidence attached (screenshots/GIF), or marked N/A
 - [ ] Risks/edge cases documented

--- a/README.md
+++ b/README.md
@@ -44,12 +44,28 @@ npm run start
 ```
 
 ## Quality checks
+Canonical contributor validation commands live in [`CONTRIBUTING.md#canonical-local-verification-commands`](./CONTRIBUTING.md#canonical-local-verification-commands).
+
+Common entry points:
+
 ```bash
+# Docs-only validation for README.md + docs/** internal links
+npm run docs:links
+
+# Fast inner-loop verification (no build)
+npm run verify:quick
+
+# Full pre-merge verification (includes build)
+npm run verify:core
+
+# Targeted checks when you need them individually
 npm run lint
 npm run typecheck
 npm run test
 npm run e2e
 ```
+
+For docs-only changes, prefer `npm run docs:links`. If local `lychee` is unavailable, use the Docker fallback documented in `CONTRIBUTING.md`. `npm run verify:core` is still recommended for broader code changes, but it does **not** replace the dedicated docs link check for README/docs edits.
 
 ## Build
 ```bash


### PR DESCRIPTION
## Summary
- define a single canonical docs-only validation path for contributors in `CONTRIBUTING.md`
- align `README.md` and the PR template with the same rule and fallback order
- make explicit that `npm run verify:core` does not replace the dedicated docs link check

## Linked Issue
- Closes #252

## 2-stage review confirmation
### Stage 1 — Self-review (author, xhigh reasoning)
- [x] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).
- [x] I confirmed the implementation satisfies the linked issue scope.

### Stage 2 — Final review (Boe)
- [ ] Final review requested from **Boe**.

## Validation evidence
### Required pre-merge verification
Not run locally for this docs/process-only change.

### Docs-only validation (required when README.md, docs/**, or docs-facing templates change)
```bash
npm run docs:links
# failed locally: sh: lychee: command not found

docker info >/dev/null && npm run docs:links:docker
# failed locally: Cannot connect to the Docker daemon at unix:///Users/syong/.orbstack/run/docker.sock. Is the docker daemon running?

git diff --check
# passed (no output)
```

### Optional targeted command outputs
Not run.

## UI changes
- [x] N/A (no UI changes)
- [ ] Screenshots/GIF attached below

## Risks / edge cases
- local docs-link validation could not be completed in this environment because both documented execution paths were unavailable (`lychee` missing locally, Docker daemon unavailable)
- CI `Markdown link check` remains the intended enforcement fallback and should verify the updated docs references

## Additional notes
- This change intentionally keeps scope to contributor docs/process surfaces: `README.md`, `CONTRIBUTING.md`, and `.github/pull_request_template.md`.
