### PR TITLE
docs: consolidate docs validation guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ npm run verify:core
 ```
 
 ### Docs-only validation (required when README.md, docs/**, or docs-facing templates change)
-See [`docs/ops/docs-validation.md`](./docs/ops/docs-validation.md) for the canonical required-vs-fallback path.
+See [`docs/ops/docs-validation.md`](../docs/ops/docs-validation.md) for the canonical required-vs-fallback path.
 
 ```bash
 # paste command + output

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,21 +13,30 @@
 - [ ] Final review requested from **Boe**.
 
 ## Validation evidence
-### Lint
+### Required pre-merge verification
 ```bash
 # paste command + output
+npm run verify:core
+```
+
+### Docs-only validation (required when README.md, docs/**, or docs-facing templates change)
+```bash
+# paste command + output
+npm run docs:links
+
+# or, if local lychee is unavailable:
+npm run docs:links:docker
+
+# if neither local lychee nor Docker is available, explain that here
+# and note that the required CI workflow "Markdown link check" is expected to catch docs-link regressions.
+```
+
+### Optional targeted command outputs
+```bash
+# paste command + output when useful
 npm run lint
-```
-
-### Tests
-```bash
-# paste command + output
+npm run typecheck
 npm test
-```
-
-### Build
-```bash
-# paste command + output
 npm run build
 ```
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,8 @@ npm run verify:core
 ```
 
 ### Docs-only validation (required when README.md, docs/**, or docs-facing templates change)
+See [`docs/ops/docs-validation.md`](./docs/ops/docs-validation.md) for the canonical required-vs-fallback path.
+
 ```bash
 # paste command + output
 npm run docs:links

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -17,7 +17,7 @@ jobs:
 
       # We only validate internal/relative links to keep this workflow fast and non-flaky.
       # External URLs are intentionally skipped.
-      - name: Check internal Markdown links (README.md + docs/**)
+      - name: Check internal Markdown links (README.md + docs/** + PR template)
         uses: lycheeverse/lychee-action@v2
         with:
           fail: true
@@ -26,4 +26,4 @@ jobs:
             --offline
             --exclude '^https?://'
             --exclude '^mailto:'
-            README.md docs
+            README.md docs .github/pull_request_template.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Do not duplicate or reword that guidance in issues, PRs, or follow-up docs updat
 Use the commands below as the canonical local validation entry points for this repo. Reference these exact commands in issues/PRs instead of inventing aliases such as `npm run verify:docs`.
 
 ```bash
-# Docs-only validation for README.md + docs/** internal links
+# Docs-only validation for README.md + docs/** + PR template internal links
 # See docs/ops/docs-validation.md for required-vs-fallback guidance.
 npm run docs:links
 # or, if local lychee is unavailable:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,34 +60,14 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 
 ## Canonical docs-only validation path
 
-CI validates **internal/relative** links in `README.md` and `docs/**` (external URLs are intentionally skipped to avoid flaky failures).
+Use [`docs/ops/docs-validation.md`](./docs/ops/docs-validation.md) as the canonical reference for:
 
-When your change is docs-only or touches `README.md`, `docs/**`, or docs-facing templates, use this fallback order:
+- when docs-link validation is required
+- which command is required vs fallback-only
+- local `lychee` vs Docker fallback steps
+- what to note in the PR when only CI can cover the check
 
-1. Preferred: run `npm run docs:links` if local `lychee` is installed.
-2. If `lychee` is unavailable locally: run `npm run docs:links:docker`.
-3. If neither local `lychee` nor Docker is available: do **not** invent another docs alias. Note in the PR that the docs link check could not be run locally, and rely on the required CI workflow **Markdown link check** to catch link regressions.
-
-Important: `npm run verify:core` is useful for broader pre-merge validation, but it does **not** run the Markdown link checker and is **not** a substitute for `npm run docs:links` / `npm run docs:links:docker` when docs links changed.
-
-```bash
-# Preferred: local lychee installed
-#   brew install lychee
-#   # or: cargo install lychee
-npm run docs:links
-
-# Fallback: no local lychee, but Docker/OrbStack is available
-#   Optional readiness check (daemon reachable):
-#   docker info >/dev/null
-npm run docs:links:docker
-
-# Equivalent direct Docker command
-# docker run --rm -v "$PWD":/workdir -w /workdir \
-#   ghcr.io/lycheeverse/lychee:latest \
-#   --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
-```
-
-If Docker reports `Cannot connect to the Docker daemon`, start Docker/OrbStack first and rerun `npm run docs:links:docker`.
+Do not duplicate or reword that guidance in issues, PRs, or follow-up docs updates; link back to the reference instead.
 
 ## Canonical local verification commands
 
@@ -95,6 +75,7 @@ Use the commands below as the canonical local validation entry points for this r
 
 ```bash
 # Docs-only validation for README.md + docs/** internal links
+# See docs/ops/docs-validation.md for required-vs-fallback guidance.
 npm run docs:links
 # or, if local lychee is unavailable:
 npm run docs:links:docker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,47 +58,53 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 - [Projects v2 auth runbook](./docs/ops/projects-v2-auth-runbook.md): Use when configuring or debugging GitHub Actions auth for workflows that read/update the Clay-Agency org Project #1 (GraphQL `ProjectV2`).
 - [Project #1 field conventions](./docs/ops/project-1-field-conventions.md): Use when triaging work on the Project #1 board or building automation that writes project fields (Status, Priority, Owner agent, Needs decision, Evidence).
 
-## Markdown link check
+## Canonical docs-only validation path
 
 CI validates **internal/relative** links in `README.md` and `docs/**` (external URLs are intentionally skipped to avoid flaky failures).
 
-Run locally:
+When your change is docs-only or touches `README.md`, `docs/**`, or docs-facing templates, use this fallback order:
+
+1. Preferred: run `npm run docs:links` if local `lychee` is installed.
+2. If `lychee` is unavailable locally: run `npm run docs:links:docker`.
+3. If neither local `lychee` nor Docker is available: do **not** invent another docs alias. Note in the PR that the docs link check could not be run locally, and rely on the required CI workflow **Markdown link check** to catch link regressions.
+
+Important: `npm run verify:core` is useful for broader pre-merge validation, but it does **not** run the Markdown link checker and is **not** a substitute for `npm run docs:links` / `npm run docs:links:docker` when docs links changed.
 
 ```bash
-# Option A: run via npm (requires lychee installed)
+# Preferred: local lychee installed
 #   brew install lychee
 #   # or: cargo install lychee
-
 npm run docs:links
 
-# Option B: Docker (no local lychee install required)
+# Fallback: no local lychee, but Docker/OrbStack is available
 #   Optional readiness check (daemon reachable):
 #   docker info >/dev/null
-
 npm run docs:links:docker
 
-# (Equivalent direct command)
-# docker run --rm -v "$(pwd)":/workdir -w /workdir \
+# Equivalent direct Docker command
+# docker run --rm -v "$PWD":/workdir -w /workdir \
 #   ghcr.io/lycheeverse/lychee:latest \
 #   --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
-
-# If you see "Cannot connect to the Docker daemon", start Docker/OrbStack first,
-# then rerun the command.
 ```
 
+If Docker reports `Cannot connect to the Docker daemon`, start Docker/OrbStack first and rerun `npm run docs:links:docker`.
 
-## Local verification commands
+## Canonical local verification commands
 
-Use the quick check during development, and full check before final review:
+Use the commands below as the canonical local validation entry points for this repo. Reference these exact commands in issues/PRs instead of inventing aliases such as `npm run verify:docs`.
 
 ```bash
+# Docs-only validation for README.md + docs/** internal links
+npm run docs:links
+# or, if local lychee is unavailable:
+npm run docs:links:docker
+
 # Fast inner-loop verification (no build)
 npm run verify:quick
 
 # Full pre-merge verification (includes build)
 npm run verify:core
 ```
-
 
 ## 2-stage review process (required)
 
@@ -122,6 +128,7 @@ After Stage 1 is complete, request final review from **Boe**.
 - [ ] Linked issue(s) included (`Closes #...`)
 - [ ] Stage 1 self-review complete (xhigh reasoning applied)
 - [ ] `npm run verify:core` result attached
+- [ ] Docs-only validation evidence attached when README.md, `docs/**`, or docs-facing templates changed (`npm run docs:links` or `npm run docs:links:docker`; otherwise explain why CI covered it)
 - [ ] (optional) individual command outputs attached when needed (`check:workflows`, `lint`, `typecheck`, `test`, `build`)
 - [ ] UI change evidence attached (screenshots/GIF), or marked N/A
 - [ ] Risks/edge cases documented

--- a/README.md
+++ b/README.md
@@ -44,12 +44,28 @@ npm run start
 ```
 
 ## Quality checks
+Canonical contributor validation commands live in [`CONTRIBUTING.md#canonical-local-verification-commands`](./CONTRIBUTING.md#canonical-local-verification-commands).
+
+Common entry points:
+
 ```bash
+# Docs-only validation for README.md + docs/** internal links
+npm run docs:links
+
+# Fast inner-loop verification (no build)
+npm run verify:quick
+
+# Full pre-merge verification (includes build)
+npm run verify:core
+
+# Targeted checks when you need them individually
 npm run lint
 npm run typecheck
 npm run test
 npm run e2e
 ```
+
+For docs-only changes, prefer `npm run docs:links`. If local `lychee` is unavailable, use the Docker fallback documented in `CONTRIBUTING.md`. `npm run verify:core` is still recommended for broader code changes, but it does **not** replace the dedicated docs link check for README/docs edits.
 
 ## Build
 ```bash

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ npm run test
 npm run e2e
 ```
 
-For docs-only changes, prefer `npm run docs:links`. If local `lychee` is unavailable, use the Docker fallback documented in `CONTRIBUTING.md`. `npm run verify:core` is still recommended for broader code changes, but it does **not** replace the dedicated docs link check for README/docs edits.
+For docs-only changes, follow the canonical docs validation reference in [`docs/ops/docs-validation.md`](./docs/ops/docs-validation.md). `npm run verify:core` is still recommended for broader code changes, but it does **not** replace the dedicated docs link check for README/docs edits.
 
 ## Build
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Canonical contributor validation commands live in [`CONTRIBUTING.md#canonical-lo
 Common entry points:
 
 ```bash
-# Docs-only validation for README.md + docs/** internal links
+# Docs-only validation for README.md + docs/** + PR template internal links
 npm run docs:links
 
 # Fast inner-loop verification (no build)
@@ -65,7 +65,7 @@ npm run test
 npm run e2e
 ```
 
-For docs-only changes, follow the canonical docs validation reference in [`docs/ops/docs-validation.md`](./docs/ops/docs-validation.md). `npm run verify:core` is still recommended for broader code changes, but it does **not** replace the dedicated docs link check for README/docs edits.
+For docs-only changes, follow the canonical docs validation reference in [`docs/ops/docs-validation.md`](./docs/ops/docs-validation.md). `npm run verify:core` is still recommended for broader code changes, but it does **not** replace the dedicated docs link check for README/docs/template edits.
 
 ## Build
 ```bash

--- a/docs/ops/docs-validation.md
+++ b/docs/ops/docs-validation.md
@@ -36,11 +36,11 @@ npm run docs:links:docker
 # Equivalent direct Docker command
 # docker run --rm -v "$PWD":/workdir -w /workdir \
 #   ghcr.io/lycheeverse/lychee:latest \
-#   --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
+#   --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs .github/pull_request_template.md
 ```
 
 If Docker reports `Cannot connect to the Docker daemon`, start Docker/OrbStack first and rerun `npm run docs:links:docker`.
 
 ## Scope of the check
 
-CI validates **internal/relative** links in `README.md` and `docs/**`. External URLs are intentionally skipped to avoid flaky failures.
+CI validates **internal/relative** links in `README.md`, `docs/**`, and `.github/pull_request_template.md`. External URLs are intentionally skipped to avoid flaky failures.

--- a/docs/ops/docs-validation.md
+++ b/docs/ops/docs-validation.md
@@ -1,0 +1,46 @@
+# Docs validation reference
+
+Use this document as the **single source of truth** for docs-link validation guidance in this repo.
+
+## When this applies
+
+Use the docs validation path when your change is docs-only or touches:
+
+- `README.md`
+- `docs/**`
+- docs-facing templates such as `.github/pull_request_template.md`
+
+## Required command vs fallback-only options
+
+Follow this order exactly:
+
+1. **Required local command when available:** `npm run docs:links`
+2. **Fallback when local `lychee` is unavailable:** `npm run docs:links:docker`
+3. **CI-only fallback when neither local `lychee` nor Docker is available:** document that in the PR and rely on the required CI workflow **Markdown link check**
+
+Important: `npm run verify:core` is useful for broader pre-merge validation, but it does **not** run the Markdown link checker and is **not** a substitute for docs-link validation when docs links changed.
+
+## Canonical commands
+
+```bash
+# Preferred: local lychee installed
+#   brew install lychee
+#   # or: cargo install lychee
+npm run docs:links
+
+# Fallback: no local lychee, but Docker/OrbStack is available
+#   Optional readiness check (daemon reachable):
+#   docker info >/dev/null
+npm run docs:links:docker
+
+# Equivalent direct Docker command
+# docker run --rm -v "$PWD":/workdir -w /workdir \
+#   ghcr.io/lycheeverse/lychee:latest \
+#   --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
+```
+
+If Docker reports `Cannot connect to the Docker daemon`, start Docker/OrbStack first and rerun `npm run docs:links:docker`.
+
+## Scope of the check
+
+CI validates **internal/relative** links in `README.md` and `docs/**`. External URLs are intentionally skipped to avoid flaky failures.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "test:watch": "vitest",
     "e2e": "playwright test",
     "check:workflows": "ruby -e 'require \"yaml\"; Dir[\".github/workflows/*.{yml,yaml}\"].sort.each { |f| YAML.load_file(f); puts \"OK #{f}\" }'",
-    "docs:links": "lychee --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
-    "docs:links:docker": "docker run --rm -v \"$PWD\":/workdir -w /workdir ghcr.io/lycheeverse/lychee:latest --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
+    "docs:links": "lychee --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs .github/pull_request_template.md",
+    "docs:links:docker": "docker run --rm -v \"$PWD\":/workdir -w /workdir ghcr.io/lycheeverse/lychee:latest --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs .github/pull_request_template.md",
     "verify:quick": "npm run check:workflows && npm run lint && npm run typecheck && npm test",
     "verify:core": "npm run verify:quick && npm run build"
   },


### PR DESCRIPTION
## Summary
- add `docs/ops/docs-validation.md` as the single reusable reference for docs-link validation guidance
- replace duplicated README / CONTRIBUTING / PR-template wording with short pointers back to that reference
- make the required-vs-fallback order explicit in one place only

## Linked Issue
- Closes #254

## 2-stage review confirmation
### Stage 1 — Self-review (author, xhigh reasoning)
- [x] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).
- [x] I confirmed the implementation satisfies the linked issue scope.

### Stage 2 — Final review (Boe)
- [ ] Final review requested from **Boe**.

## Validation evidence
### Required pre-merge verification
Not run for this docs-only change.

### Docs-only validation (required when README.md, docs/**, or docs-facing templates change)
Attempted local fallback order from `docs/ops/docs-validation.md`:

```bash
npm run docs:links
# sh: lychee: command not found

npm run docs:links:docker
# docker: Cannot connect to the Docker daemon at unix:///Users/syong/.orbstack/run/docker.sock
```

Per the canonical guidance, this PR relies on the required CI workflow **Markdown link check** to catch docs-link regressions.

### Optional targeted command outputs
Verified the referenced docs paths exist after the refactor:

```bash
python3 - <<'PY'
from pathlib import Path
repo = Path('.').resolve()
for rel in [
    'docs/ops/docs-validation.md',
    'README.md',
    'CONTRIBUTING.md',
    '.github/pull_request_template.md',
]:
    p = repo / rel
    print(('OK' if p.exists() else 'MISSING'), rel)
PY
```

## UI changes
- [x] N/A (no UI changes)
- [ ] Screenshots/GIF attached below

## Risks / edge cases
- local docs-link validation could not run in this environment; correctness depends on CI for final link-check confirmation

## Additional notes
- this change intentionally keeps the command names unchanged and only consolidates the guidance location
