### PR TITLE
docs: reduce Project #1 review queue duplication

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,8 @@
 ## Linked Issue
 - Closes #
 
+> Project #1 review-queue convention: keep the **issue item** as the actionable `Review` item and add this PR URL to that issue item's **Evidence** field. Do **not** add this PR to Project #1 when it would duplicate the linked issue.
+
 ## 2-stage review confirmation
 ### Stage 1 — Self-review (author, xhigh reasoning)
 - [ ] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,15 @@ When you add an issue/PR to the **Clay-Agency org Project #1** board, keep these
 - **Needs decision**: set `True` (and apply label `needs-decision`) only when progress is blocked on an explicit Clay decision. Put the decision question + options in the issue.
 - **Evidence**: paste the key links that justify the current state (PR, CI run, screenshots/GIFs, decision record). Keep it short; one item per line.
 
+### Review queue convention (Project #1)
+
+To avoid duplicate `Review` queue items for the same work:
+
+- Treat the **issue** as the canonical/actionable Project #1 item.
+- When a PR is ready, move the **issue item** to `Review`.
+- Add the PR link to the issue item’s **Evidence** field instead of adding the PR itself to Project #1.
+- Only add a PR to Project #1 when the PR is the primary work item and there is no controlling issue.
+
 Details: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
 
 ## Needs-decision convention

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -15,8 +15,14 @@ Conventions:
 - **Todo**: work not started / no one actively driving it yet.
 - **In progress**: an agent is actively working (usually set `Owner agent`).
 - **Blocked**: cannot proceed due to an external dependency (access, upstream change, waiting on review, etc.). If the blocker is a **decision**, set `Needs decision=True` and state the decision request in the issue.
-- **Review**: implementation is done and waiting on review/merge (typically there is an open PR).
+- **Review**: implementation is done and waiting on review/merge (typically there is an open PR). In Project #1, **Review should track the issue item, not a duplicate PR item, for the same underlying work**.
 - **Done**: work is complete (merged/closed) and no further action is expected.
+
+Review queue convention:
+- Treat the **issue** as the canonical/actionable Project #1 item for a unit of work.
+- When implementation is ready for review, move the **issue item** to `Review` and add the PR URL to the issue item's `Evidence` field.
+- **Do not add the implementation PR to Project #1** when it would duplicate the issue already being tracked. This keeps heartbeat/review queues low-noise.
+- Exception: a PR may be added to Project #1 only when the **PR itself is the primary work item** (for example, repo-maintenance work with no controlling issue). In that case, the PR item can carry the actionable status.
 
 ## Priority (single select)
 
@@ -57,11 +63,11 @@ Conventions:
 ## Evidence (text)
 
 Conventions:
-- Use this field as the **living link hub** for the issue/PR. Keep it short (typically 1–5 lines).
+- Use this field as the **living link hub** for the canonical Project item (usually the issue). Keep it short (typically 1–5 lines).
 - Prefer durable URLs (PR link, Actions run link, doc/decision record path, screenshot/GIF link).
 - Suggested format (one item per line):
   - `PR: <url>`
   - `CI: <url>`
   - `Decision record: docs/decisions/DR-XXXX-...md`
   - `QA evidence: <url or docs/qa/...#anchor>`
-- When moving work to **Review** or **Done**, make sure the Evidence field includes the relevant PR/merge reference.
+- When moving work to **Review** or **Done**, make sure the canonical item’s Evidence field includes the relevant PR/merge reference.

--- a/docs/ops/project-status-sync.md
+++ b/docs/ops/project-status-sync.md
@@ -8,6 +8,16 @@ It syncs **Clay-Agency org Project #1** (Projects v2 / `ProjectV2`) fields when:
 - on a daily scheduled reconciliation
 - manually via `workflow_dispatch`
 
+## Relationship to the Review queue convention
+
+Project #1 review should normally track the **issue item**, not a duplicate PR item, for the same unit of work. Under that convention:
+
+- when a linked PR is merged and the PR is **not** in Project #1, the PR event is expected to no-op
+- the linked **issue** remains the canonical Project item and is the item that should move to `Done` on issue close
+- the issue item’s `Evidence` field should carry the PR link while work is in `Review`
+
+This workflow does **not** decide which item should be in `Review`; it only syncs closed/merged items to `Done`-style fields.
+
 ## Token / permissions (Projects v2)
 
 Detailed setup (GitHub App least-privilege, PAT fallback, troubleshooting): [`docs/ops/projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md).


### PR DESCRIPTION
## Summary
- define an issue-centric Project #1 `Review` convention so the queue tracks the issue item, not a duplicate PR item
- update contributor/process docs to route PR links through the issue item's `Evidence` field
- clarify in the project-status-sync runbook that PR merge events may no-op when the PR is intentionally not added to Project #1

## Linked Issue
- Closes #256

## 2-stage review confirmation
### Stage 1 — Self-review (author, xhigh reasoning)
- [x] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).
- [x] I confirmed the implementation satisfies the linked issue scope.

### Stage 2 — Final review (Boe)
- [x] Final review requested from **Boe**.

## Validation evidence
### Required pre-merge verification
```bash
# docs/process-only change; not run
npm run verify:core
```

### Docs-only validation (required when README.md, docs/**, or docs-facing templates change)
See [`docs/ops/docs-validation.md`](./docs/ops/docs-validation.md) for the canonical required-vs-fallback path.

```bash
# local lychee unavailable in this environment
npm run docs:links
# sh: lychee: command not found

# Docker fallback unavailable in this environment
npm run docs:links:docker
# docker: Cannot connect to the Docker daemon at unix:///Users/syong/.orbstack/run/docker.sock. Is the docker daemon running?

# per repo guidance, rely on CI workflow "Markdown link check" to catch docs-link regressions
```

### Optional targeted command outputs
```bash
git diff --check
# (no output)
```

## UI changes
- [x] N/A (no UI changes)
- [ ] Screenshots/GIF attached below

## Risks / edge cases
- This is a docs/process change only; enforcement remains convention-based until/unless future automation is added.
- Existing duplicate PR items already in Project #1 may still need one-time manual cleanup.

## Additional notes
- Updated files:
  - `docs/ops/project-1-field-conventions.md`
  - `CONTRIBUTING.md`
  - `.github/pull_request_template.md`
  - `docs/ops/project-status-sync.md`
