### PR TITLE
docs: add Project #1 review queue cleanup runbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ When you add an issue/PR to the **Clay-Agency org Project #1** board, keep these
 - **Evidence**: paste the key links that justify the current state (PR, CI run, screenshots/GIFs, decision record). Keep it short; one item per line.
 
 Details: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
+If Project #1 still has older duplicate review items, use the cleanup runbook: [`docs/ops/project-1-review-queue-cleanup.md`](./docs/ops/project-1-review-queue-cleanup.md)
 
 ## Needs-decision convention
 

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -16,6 +16,7 @@ Conventions:
 - **In progress**: an agent is actively working (usually set `Owner agent`).
 - **Blocked**: cannot proceed due to an external dependency (access, upstream change, waiting on review, etc.). If the blocker is a **decision**, set `Needs decision=True` and state the decision request in the issue.
 - **Review**: implementation is done and waiting on review/merge (typically there is an open PR).
+- If older Project #1 entries left both the issue item and PR item in `Review` for the same work, use the cleanup runbook: [`docs/ops/project-1-review-queue-cleanup.md`](./project-1-review-queue-cleanup.md)
 - **Done**: work is complete (merged/closed) and no further action is expected.
 
 ## Priority (single select)

--- a/docs/ops/project-1-review-queue-cleanup.md
+++ b/docs/ops/project-1-review-queue-cleanup.md
@@ -1,0 +1,75 @@
+# Project #1 review queue cleanup runbook (Issue #258)
+
+Use this runbook when **Clay-Agency org Project #1** still contains legacy **PR items** in `Review` that duplicate a canonical **issue item** already tracking the same work.
+
+This is a **one-time / occasional hygiene task** for older items created before the issue-centric review convention was documented.
+
+Related convention: [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+
+## Goal
+
+Keep exactly **one actionable `Review` item per unit of work**:
+- keep the **issue item** in Project #1
+- keep the PR URL in the issue item’s **Evidence** field
+- remove the redundant **PR item** from Project #1
+
+## When a PR item is safe to remove
+
+A Project #1 PR item is safe to delete when **all** of the following are true:
+
+1. The PR has a controlling issue that is also in Project #1.
+2. The **issue item** is the intended actionable item (usually `Review`).
+3. The issue item’s **Evidence** field already includes the PR URL.
+4. The PR item does **not** represent standalone repo-maintenance work with no controlling issue.
+
+If any of the above is false, **do not delete the PR item** until the issue item is corrected or the exception is confirmed.
+
+## Manual review steps
+
+1. Open Project #1 and filter `Status = Review`.
+2. Look for issue/PR pairs representing the same work.
+3. For each pair:
+   - open the **issue item**
+   - confirm its **Evidence** field includes the PR link
+   - confirm the issue item is the one that should remain actionable
+4. Delete only the duplicate **PR item** from the project.
+5. Re-check the review queue to confirm only the issue item remains.
+
+## CLI-assisted audit
+
+List Project #1 items as JSON:
+
+```bash
+gh project item-list 1 --owner Clay-Agency --limit 250 --format json
+```
+
+A typical duplicate pair will look like:
+- issue item in `Review` with `Evidence: PR: <url>`
+- PR item in `Review` pointing to the same PR URL
+
+## CLI cleanup
+
+Delete the redundant PR item by its **project item ID**:
+
+```bash
+gh project item-delete 1 --owner Clay-Agency --id <project-item-id>
+```
+
+Example legacy duplicates observed while opening Issue #258:
+- issue #217 / PR #235
+- issue #220 / PR #237
+- issue #230 / PR #249
+- issue #250 / PR #251
+
+## Safety notes
+
+- Deleting a **project item** does **not** delete the GitHub PR itself.
+- Prefer deleting only the PR item after the issue item’s `Evidence` is confirmed.
+- If unsure, leave the item in place and add a note/evidence link to the issue for follow-up.
+
+## Expected result
+
+After cleanup:
+- Project #1 `Review` shows the **issue items** as the canonical queue
+- each issue item carries the PR link in **Evidence**
+- duplicate PR review items are gone


### PR DESCRIPTION
## Summary
- add a small runbook for safely removing legacy duplicate PR items from Clay-Agency Project #1 `Review`
- link that cleanup runbook from the existing Project #1 field guidance and contributor docs
- complete the one-time live cleanup so the review queue keeps the issue item as the actionable item

## Linked Issue
- Closes #258

## What was cleaned in Project #1
Removed redundant PR review items whose paired issue items already remained in `Review` with the same PR URL in `Evidence`.

Confirmed duplicate pairs cleaned:
- #212 / #213
- #215 / #216
- #217 / #235
- #218 / #236
- #219 / #239
- #220 / #237
- #221 / #238
- #222 / #241
- #223 / #242
- #224 / #244
- #225 / #245
- #226 / #240
- #227 / #246
- #228 / #247
- #229 / #243
- #230 / #249
- #232 / #248
- #233 / #234
- #250 / #251
- #252 / #253
- #254 / #255
- #256 / #257

Post-cleanup check:
```bash
gh project item-list 1 --owner Clay-Agency --limit 250 --format json \
  --jq '[.items[] | select(.status=="Review" and .content.type=="PullRequest") | {number: .content.number, title}]'
# []
```

## 2-stage review confirmation
### Stage 1 — Self-review (author, xhigh reasoning)
- [x] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).
- [x] I confirmed the implementation satisfies the linked issue scope.

### Stage 2 — Final review (Boe)
- [x] Final review requested from **Boe**.

## Validation evidence
### Required pre-merge verification
```bash
# docs/process-only change; not run
npm run verify:core
```

### Lightweight relevant validation
```bash
git diff --check
# (no output)

node - <<'NODE'
const fs = require('fs');
const text = fs.readFileSync('docs/ops/project-1-review-queue-cleanup.md','utf8');
const links = [...text.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map(m => m[1]).filter(h => !/^(https?:|mailto:|#)/.test(h));
const path = require('path');
for (const link of links) {
  const resolved = path.normalize(path.join('docs/ops', link));
  if (!fs.existsSync(resolved)) throw new Error(`broken relative link: ${link} -> ${resolved}`);
}
console.log('relative-links-ok', links.length);
NODE
# relative-links-ok 1
```

## UI changes
- [x] N/A (no UI changes)

## Risks / edge cases
- The runbook assumes the controlling issue item already contains the PR URL in `Evidence`; operators should verify that before deleting any PR item.
- This PR documents and links the cleanup path, but future prevention still depends on contributors following the review-queue convention.
