### PR TITLE
docs: define Project #1 PR-duplicate prevention plan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ When you add an issue/PR to the **Clay-Agency org Project #1** board, keep these
 - **Evidence**: paste the key links that justify the current state (PR, CI run, screenshots/GIFs, decision record). Keep it short; one item per line.
 
 Details: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
+To prevent linked implementation PR duplicates from reappearing, use the prevention plan: [`docs/ops/project-1-pr-item-dedupe-prevention.md`](./docs/ops/project-1-pr-item-dedupe-prevention.md)
 
 ## Needs-decision convention
 

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -16,6 +16,7 @@ Conventions:
 - **In progress**: an agent is actively working (usually set `Owner agent`).
 - **Blocked**: cannot proceed due to an external dependency (access, upstream change, waiting on review, etc.). If the blocker is a **decision**, set `Needs decision=True` and state the decision request in the issue.
 - **Review**: implementation is done and waiting on review/merge (typically there is an open PR).
+- If a linked implementation PR creates a duplicate Project item, keep the **issue item** as canonical and follow the prevention plan: [`project-1-pr-item-dedupe-prevention.md`](./project-1-pr-item-dedupe-prevention.md)
 - **Done**: work is complete (merged/closed) and no further action is expected.
 
 ## Priority (single select)

--- a/docs/ops/project-1-pr-item-dedupe-prevention.md
+++ b/docs/ops/project-1-pr-item-dedupe-prevention.md
@@ -1,0 +1,88 @@
+# Project #1 duplicate PR-item prevention plan (Issue #260)
+
+Use this guide to **prevent duplicate PR items from reappearing** in **Clay-Agency org Project #1** after the one-time cleanup tracked in issue #258 / PR #259.
+
+Related convention: [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+
+## Canonical rule
+
+For normal implementation work:
+- the **issue item** is the canonical Project #1 record
+- the linked PR URL belongs in the issue item's **Evidence** field
+- a duplicate **PR item** should not remain in Project #1 once the issue item is present
+
+Exception:
+- a **standalone PR** with **no controlling issue** may remain as its own Project item when it represents legitimate repo-maintenance or ops work
+
+## Decision: preferred automation path
+
+Use **workflow automation** as the primary prevention path, with manual cleanup as the fallback.
+
+Chosen shape:
+1. Trigger on PR lifecycle events where duplicate items commonly reappear (`opened`, `reopened`, `ready_for_review`, and `edited` when issue references may change).
+2. Inspect whether the PR has a **controlling issue**.
+3. If the controlling issue already exists in Project #1, treat the issue item as canonical and remove only the duplicate PR item.
+4. If the workflow cannot prove the relationship safely, it should **skip** deletion and leave manual cleanup as the fallback path.
+
+Why this is preferred over the alternatives:
+- **Better than cron**: duplicates are removed near the moment they appear instead of lingering until a scheduled reconcile.
+- **Better than manual-only wrappers**: prevention becomes the default path instead of depending on humans to remember cleanup.
+- **Safer than broad project filters**: we still allow legitimate standalone PR items that do not have a controlling issue.
+
+## Guardrails for safe auto-removal
+
+Automation should delete a PR item from Project #1 only when **all** of the following are true:
+
+1. The PR has a **controlling issue** (for example, a closing reference such as `Closes #123`, or another repo-approved link signal).
+2. The controlling **issue item already exists in Project #1**.
+3. The PR item and issue item clearly refer to the **same unit of work**.
+4. The issue item is the intended actionable queue item under the review convention.
+5. The PR is **not** a standalone maintenance/ops change that intentionally lives in Project #1 without a controlling issue.
+
+If any guardrail is not satisfied, automation should:
+- leave the PR item in place
+- log a clear skip reason in the workflow summary
+- require manual follow-up instead of guessing
+
+## Recommended implementation contract
+
+If/when this is implemented in GitHub Actions or a repo script, keep the behavior narrow:
+
+- **Input**: one PR event at a time
+- **Lookup**:
+  - resolve the PR's Project #1 item, if any
+  - resolve the controlling issue's Project #1 item, if any
+- **Mutation**:
+  - delete only the **project item** for the PR
+  - never close, edit, or delete the PR itself
+- **Fallback**:
+  - if the controlling issue cannot be resolved confidently, do nothing automatically
+
+Optional but useful summary output:
+- `removed duplicate PR item for #<pr> because issue #<issue> is canonical`
+- `skipped: no controlling issue found`
+- `skipped: issue exists but is not in Project #1`
+- `skipped: Evidence/relationship needs manual confirmation`
+
+## Manual fallback
+
+If duplicates still appear, use a narrow manual cleanup pass:
+
+1. Open Project #1 and filter `Status = Review`.
+2. Find issue/PR pairs representing the same work.
+3. Confirm the **issue item** is the canonical queue item and already contains the PR URL in **Evidence**.
+4. Delete only the duplicate **PR item** from Project #1.
+5. Re-check the review queue to confirm only the issue item remains.
+
+This manual path remains the safer option for:
+- legacy items created before automation lands
+- ambiguous issue/PR relationships
+- one-off exceptions where human review is safer than automatic deletion
+
+## Non-goals
+
+This prevention path should **not**:
+- remove standalone PR items that have no controlling issue
+- rewrite the team's issue-centric review convention
+- depend on a daily cron job as the only line of defense
+- assume every PR in Project #1 is a duplicate


### PR DESCRIPTION
## Summary
- add a dedicated ops doc for preventing duplicate PR items from reappearing in Clay-Agency Project #1
- choose **workflow automation** as the primary prevention path, with manual cleanup as the safe fallback
- document the narrow auto-removal guardrails so only linked implementation PR duplicates are targeted
- link the prevention plan from the existing Project #1 field guidance and contributor docs

## Linked Issue
- Closes #260

## Decision captured
Preferred path for #260:
- **Primary:** workflow automation on PR lifecycle events
- **Not primary:** cron-only cleanup
- **Not primary:** manual-only command wrapper

Reasoning:
- catches duplicates close to creation time
- preserves standalone PR items that have no controlling issue
- keeps deletion scoped to the Project item only
- falls back to manual review when the issue/PR relationship is ambiguous

## Validation evidence
### Lint
```bash
# docs-only change; not run
npm run lint
```

### Tests
```bash
# docs-only change; not run
npm test
```

### Build
```bash
# docs-only change; not run
npm run build
```

### Lightweight relevant validation
```bash
git diff --check
# no output

node - <<'NODE'
const fs = require('fs');
const path = require('path');
const files = [
  'docs/ops/project-1-pr-item-dedupe-prevention.md',
  'docs/ops/project-1-field-conventions.md',
  'CONTRIBUTING.md',
];
for (const file of files) {
  const text = fs.readFileSync(file, 'utf8');
  const links = [...text.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map(m => m[1]).filter(h => !/^(https?:|mailto:|#)/.test(h));
  for (const link of links) {
    const resolved = path.normalize(path.join(path.dirname(file), link));
    if (!fs.existsSync(resolved)) throw new Error(`${file}: broken relative link ${link} -> ${resolved}`);
  }
  console.log(`${file}: relative-links-ok (${links.length})`);
}
NODE
# docs/ops/project-1-pr-item-dedupe-prevention.md: relative-links-ok (1)
# docs/ops/project-1-field-conventions.md: relative-links-ok (1)
# CONTRIBUTING.md: relative-links-ok (5)
```

## UI changes
- [x] N/A (no UI changes)
- [ ] Screenshots/GIF attached below

## Risks / edge cases
- The new doc intentionally stops at a **policy + guardrail** decision; it does not implement the workflow yet.
- Safe deletion still depends on reliably resolving the PR's controlling issue before any automation is built.
- Main does not yet contain the #258 cleanup-runbook PR, so this PR keeps the manual fallback steps self-contained instead of linking to an unmerged local doc.

## Additional notes
- This is a docs/research-only change scoped to #260.
- When the implementation issue is picked up later, the existing `project-status-sync` workflow/script family is the most natural place to extend rather than inventing a separate broad cleanup cron.
