### PR TITLE
docs: define stacked Project #1 follow-up PR handling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,4 +39,4 @@ npm run build
 - 
 
 ## Additional notes
-- 
+- If this PR is intentionally stacked on another open PR, note `Depends on #...`, explain the temporary base branch, and plan to retarget/rebase to `main` after the prerequisite merges.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ nvm use
 1. Branch from `main` with `feat/issue-<number>-<summary>`.
 2. Keep commits scoped to one issue.
 3. Open a PR that links the issue (example: `Closes #14`).
-4. Follow the **2-stage review process** below before requesting merge.
+4. Prefer PRs targeting `main`. If a Project #1 follow-up PR must temporarily stack on another open PR for clean scope, document the dependency in the PR body (for example `Depends on #261`) and follow the runbook: [`docs/ops/project-1-stacked-follow-up-prs.md`](./docs/ops/project-1-stacked-follow-up-prs.md).
+5. Follow the **2-stage review process** below before requesting merge.
 
 
 ## Where to file what
@@ -57,6 +58,7 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 
 - [Projects v2 auth runbook](./docs/ops/projects-v2-auth-runbook.md): Use when configuring or debugging GitHub Actions auth for workflows that read/update the Clay-Agency org Project #1 (GraphQL `ProjectV2`).
 - [Project #1 field conventions](./docs/ops/project-1-field-conventions.md): Use when triaging work on the Project #1 board or building automation that writes project fields (Status, Priority, Owner agent, Needs decision, Evidence).
+- [Project #1 stacked follow-up PR handling](./docs/ops/project-1-stacked-follow-up-prs.md): Use when a Project #1 follow-up PR is intentionally based on another still-open PR and needs later retarget/rebase onto `main`.
 
 ## Markdown link check
 

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -16,6 +16,7 @@ Conventions:
 - **In progress**: an agent is actively working (usually set `Owner agent`).
 - **Blocked**: cannot proceed due to an external dependency (access, upstream change, waiting on review, etc.). If the blocker is a **decision**, set `Needs decision=True` and state the decision request in the issue.
 - **Review**: implementation is done and waiting on review/merge (typically there is an open PR).
+- If a follow-up PR is intentionally stacked on another open PR, keep the issue item canonical and follow the stacked-PR handling guide: [`project-1-stacked-follow-up-prs.md`](./project-1-stacked-follow-up-prs.md)
 - **Done**: work is complete (merged/closed) and no further action is expected.
 
 ## Priority (single select)

--- a/docs/ops/project-1-stacked-follow-up-prs.md
+++ b/docs/ops/project-1-stacked-follow-up-prs.md
@@ -1,0 +1,103 @@
+# Project #1 stacked follow-up PR handling (Issue #264)
+
+Use this guide when a **Project #1 follow-up PR** is intentionally opened on top of another still-open PR instead of directly on `main`.
+
+## Default rule
+
+Prefer PRs that target **`main`**.
+
+A stacked PR is an exception, not the default. Use it only when it keeps scope materially cleaner than folding the work into the prerequisite PR or waiting for the prerequisite to merge first.
+
+## When stacking is acceptable
+
+Stacking is acceptable when **all** of the following are true:
+
+1. The follow-up work is a **separate issue or reviewable unit**.
+2. The prerequisite PR is already the right place for the lower-layer change and should stay narrowly scoped.
+3. Rebasing the follow-up work onto `main` **before** the prerequisite merges would create misleading noise, duplicated edits, or incomplete behavior.
+4. The PR description clearly states the dependency (for example: `Depends on #261`) and explains that the base branch is temporary.
+5. Reviewers can still meaningfully review the follow-up PR by focusing on the delta from the prerequisite PR.
+
+Typical acceptable cases:
+- docs/process follow-up that depends on another docs/process PR landing first
+- automation follow-up that builds directly on a policy/runbook PR already under review
+- narrowly layered refactors where the lower layer and upper layer should be reviewed separately
+
+## When work should rebase to `main` before review
+
+Do **not** stack the PR when any of the following is true:
+
+- the work can cleanly target `main` without losing clarity
+- the prerequisite PR is likely to merge immediately, so waiting is simpler than stacking
+- the stacked diff would make review confusing or hide the true net change
+- the follow-up PR is not independently understandable without reading a large dependent chain
+- the stack is being used mainly to avoid merge conflicts rather than preserve clean scope
+
+If in doubt, prefer:
+1. merge/review the prerequisite first, then
+2. rebase the follow-up branch onto `main`, then
+3. open or update the follow-up PR against `main`
+
+## Author requirements for stacked follow-up PRs
+
+If a stacked PR is necessary, the author should:
+
+1. Keep it scoped to its own issue.
+2. Set the PR base to the prerequisite branch only for as long as needed.
+3. Add an explicit note in the PR body such as:
+   - `Depends on #261 landing first (temporary base: feat/issue-260-...)`
+4. Keep the controlling issue as the canonical Project #1 item.
+5. Add/update the issue item's **Evidence** field with the follow-up PR URL when the PR is ready for review.
+6. After the prerequisite merges, promptly retarget/rebase so the PR ends up targeting `main`.
+
+## Maintainer checklist after the prerequisite PR merges
+
+When the lower PR merges first, maintainers (or the PR author) should do this promptly for each stacked follow-up PR:
+
+1. **Confirm dependency landed**
+   - verify the prerequisite PR is merged into `main`
+2. **Retarget the PR base to `main`**
+   - change the GitHub PR base from the prerequisite branch to `main`
+3. **Rebase or merge `main` into the follow-up branch**
+   - prefer a clean rebase when practical
+   - resolve conflicts, if any
+4. **Sanity-check the diff**
+   - confirm the PR now shows only the intended net-new changes
+   - remove any already-merged prerequisite commits from the visible diff
+5. **Refresh validation as needed**
+   - rerun the lightweight relevant checks for the follow-up PR
+6. **Update the PR body**
+   - replace the temporary stack note with a short note that the PR has been retargeted/rebased onto `main`
+7. **Reconfirm Project #1 evidence**
+   - ensure the controlling issue item still has the correct PR URL and status context
+
+## Recommended PR-body language
+
+For an intentionally stacked follow-up PR, add a short note like:
+
+```md
+Depends on #261 landing first (temporary base set to its branch for clean scope).
+After #261 merges, this PR should be retargeted/rebased onto `main`.
+```
+
+After retargeting/rebasing, replace it with:
+
+```md
+Originally stacked on #261 for clean scope; now retargeted/rebased onto `main` after #261 merged.
+```
+
+## Project #1 convention impact
+
+Stacking does **not** change the Project #1 canonical-item rule:
+
+- keep the **issue item** as the canonical queue item
+- use the issue item's **Evidence** field to hold the active PR link(s)
+- do not rely on the temporary stacked PR base as workflow state; clear it once the prerequisite lands
+
+## Non-goals
+
+This guidance does **not**:
+- require every follow-up PR to be stacked
+- permit long-lived multi-PR chains by default
+- replace normal preference for `main`-based review
+- automate retarget/rebase steps by itself


### PR DESCRIPTION
## Summary
- add a dedicated ops runbook for handling intentionally stacked Project #1 follow-up PRs
- define when stacking is acceptable versus when work should target or rebase back to `main`
- add a maintainer checklist for retargeting/rebasing stacked PRs after the prerequisite merges
- link the new guidance from the Project #1 field conventions, contributing guide, and PR template

## Linked Issue
- Closes #264

## Decision captured
Preferred handling for Project #1 follow-up PRs:
- **Default:** target `main`
- **Allowed exception:** temporarily stack on another open PR only when it preserves a cleaner, separately reviewable scope
- **Required follow-through:** once the prerequisite merges, promptly retarget/rebase the follow-up PR onto `main`

## Validation evidence
### Lint
```bash
# docs-only change; not run
npm run lint
```

### Tests
```bash
# docs-only change; not run
npm test
```

### Build
```bash
# docs-only change; not run
npm run build
```

### Lightweight relevant validation
```bash
git diff --check
# no output

node - <<'NODE'
const fs = require('fs');
const path = require('path');
const files = [
  'docs/ops/project-1-stacked-follow-up-prs.md',
  'docs/ops/project-1-field-conventions.md',
  'CONTRIBUTING.md',
  '.github/pull_request_template.md',
];
for (const file of files) {
  const text = fs.readFileSync(file, 'utf8');
  const links = [...text.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map(m => m[1]).filter(h => !/^(https?:|mailto:|#)/.test(h));
  for (const link of links) {
    const resolved = path.normalize(path.join(path.dirname(file), link));
    if (!fs.existsSync(resolved)) throw new Error(`${file}: broken relative link ${link} -> ${resolved}`);
  }
  console.log(`${file}: relative-links-ok (${links.length})`);
}
NODE
# docs/ops/project-1-stacked-follow-up-prs.md: relative-links-ok (0)
# docs/ops/project-1-field-conventions.md: relative-links-ok (1)
# CONTRIBUTING.md: relative-links-ok (6)
# .github/pull_request_template.md: relative-links-ok (0)
```

## UI changes
- [x] N/A (no UI changes)
- [ ] Screenshots/GIF attached below

## Risks / edge cases
- This change documents process only; it does not automate retarget/rebase behavior.
- The guidance intentionally prefers short-lived stacking and does not define long multi-PR chains as normal workflow.
- Existing already-stacked PRs still need manual follow-through after prerequisite merges.

## Additional notes
- Evidence motivating this issue is the current #263-on-#261 stack, which needs retarget/rebase after #261 lands.
- The new runbook keeps the Project #1 issue item canonical even when the implementation PR is temporarily stacked.
