### PR TITLE
docs: add Project #1 merge-order checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 
 - [Projects v2 auth runbook](./docs/ops/projects-v2-auth-runbook.md): Use when configuring or debugging GitHub Actions auth for workflows that read/update the Clay-Agency org Project #1 (GraphQL `ProjectV2`).
 - [Project #1 field conventions](./docs/ops/project-1-field-conventions.md): Use when triaging work on the Project #1 board or building automation that writes project fields (Status, Priority, Owner agent, Needs decision, Evidence).
+- [Project #1 review merge-order checklist](./docs/ops/project-1-review-merge-order-checklist.md): Use when several Project #1 items are in `Review` and maintainers need a consistent dependency-aware merge order.
 
 ## Markdown link check
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ npm run build
 ### Quick links
 - Projects v2 auth runbook: [`docs/ops/projects-v2-auth-runbook.md`](./docs/ops/projects-v2-auth-runbook.md)
 - Project #1 field conventions: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
+- Project #1 review merge-order checklist: [`docs/ops/project-1-review-merge-order-checklist.md`](./docs/ops/project-1-review-merge-order-checklist.md)
 - Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)
 - Branch protection runbook (require **Verify (core)** on `main`): [`docs/ops/branch-protection.md`](./docs/ops/branch-protection.md)
 

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -15,7 +15,7 @@ Conventions:
 - **Todo**: work not started / no one actively driving it yet.
 - **In progress**: an agent is actively working (usually set `Owner agent`).
 - **Blocked**: cannot proceed due to an external dependency (access, upstream change, waiting on review, etc.). If the blocker is a **decision**, set `Needs decision=True` and state the decision request in the issue.
-- **Review**: implementation is done and waiting on review/merge (typically there is an open PR).
+- **Review**: implementation is done and waiting on review/merge (typically there is an open PR). For merge sequencing when several review items are ready at once, use [`project-1-review-merge-order-checklist.md`](./project-1-review-merge-order-checklist.md).
 - **Done**: work is complete (merged/closed) and no further action is expected.
 
 ## Priority (single select)

--- a/docs/ops/project-1-review-merge-order-checklist.md
+++ b/docs/ops/project-1-review-merge-order-checklist.md
@@ -1,0 +1,134 @@
+# Project #1 review merge-order checklist (Issue #266)
+
+Use this checklist when **multiple Project #1 items are in `Review` at the same time** and maintainers need a low-friction way to decide **what merges first**.
+
+Goal: keep the queue aligned with the **issue-first review convention**, avoid merge-order mistakes on related PRs, and make the **post-merge Project updates** predictable.
+
+Related docs:
+- [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+- [`project-status-sync.md`](./project-status-sync.md)
+
+## Default principles
+
+1. **Treat the issue item as canonical.**
+   - For normal issue-driven work, the **issue** is the actionable Project #1 item.
+   - The PR is supporting evidence, not a second canonical queue entry.
+
+2. **Merge prerequisites before follow-ups.**
+   - If PR B depends on PR A, merge **A before B**.
+   - Do not merge a follow-up PR just because it is green if its base assumptions still depend on an unmerged prerequisite.
+
+3. **Prefer simpler policy/docs changes before dependent automation or implementation changes.**
+   - When a docs/process PR defines the rule and a later PR implements or automates it, merge the rule-setting PR first.
+
+4. **Keep stacked PRs short-lived.**
+   - A temporarily stacked PR is acceptable when it keeps scope clean.
+   - Once the base PR merges, promptly retarget/rebase the follow-up PR onto `main` before final merge if needed.
+
+5. **After merge, update the issue evidence/status promptly.**
+   - The issue item's `Evidence` field should show the relevant PR/merge reference.
+   - The issue item's `Status` should reflect whether the issue is now truly done or still waiting on another follow-up.
+
+## Maintainer checklist
+
+### 1) Start from the controlling issue, not from the PR list
+
+For each review-ready PR:
+- identify the **controlling issue** (`Closes #...` or equivalent explicit linkage)
+- confirm whether the **issue item** already exists in Project #1
+- review/triage the work against the **issue item** as the canonical record
+
+If both an issue item and PR item appear in Project #1 for the same work:
+- treat the **issue item** as canonical
+- use the PR URL in the issue item's `Evidence` field
+- avoid using the duplicate PR item as the merge-order source of truth
+
+### 2) Group the queue by dependency shape
+
+Before merging, sort review items into these buckets:
+
+- **Independent items**: can merge in any order.
+- **Issue follow-up items**: a later PR/refinement depends on an earlier issue or decision landing first.
+- **Stacked PRs**: the PR branch itself targets another open PR instead of `main`.
+
+If an item belongs to a dependency chain, do **not** merge it purely by queue age or green CI.
+
+### 3) Decide the merge order using this priority ladder
+
+When several items are all green, use this order:
+
+1. **Dependency bases first**
+   - Merge the earliest prerequisite/base PR first.
+   - Example: if `#263` depends on `#261`, merge `#261` first.
+
+2. **Rule-setting docs/process changes before dependent automation/code**
+   - If one PR establishes the maintainer convention and another automates or extends it, merge the convention-setting PR first.
+
+3. **Independent, low-risk items before larger follow-ups when no dependency exists**
+   - Prefer the smaller, self-contained review item if it does not block something else.
+
+4. **Blocked stacked follow-ups only after retarget/rebase is clean**
+   - After the base PR merges, confirm the follow-up PR has been rebased or retargeted appropriately.
+   - Re-run or confirm green CI if the retarget/rebase changed the effective diff.
+
+### 4) Handle stacked PRs explicitly
+
+If a PR is stacked on another open PR:
+
+- check the PR **base branch**
+- confirm which base PR must merge first
+- merge the base PR before the stacked follow-up
+- after the base merges, ensure the follow-up PR is:
+  - retargeted to `main`, or
+  - rebased onto the updated `main`
+- re-check that the follow-up PR still has:
+  - clean scope
+  - correct linked issue
+  - green CI
+
+Do **not** treat a stacked PR as immediately mergeable just because GitHub shows it as clean against its temporary base.
+
+### 5) Use the issue-first review convention during merge
+
+At merge time:
+- review the PR in the context of the **issue item**
+- make sure the issue item's `Evidence` field contains the PR URL before or at merge time
+- avoid leaving both the issue item and a duplicate PR item as parallel `Review` records for the same work
+
+Recommended `Evidence` lines:
+- `PR: <url>` while waiting in `Review`
+- `Merged: <url>` or `PR: <url>` after merge, depending on existing board habit
+
+### 6) Update Project status after merge
+
+After a PR merges, decide whether the controlling issue should move to `Done` or stay open for a follow-up.
+
+Move the issue item to **Done** when:
+- the merged PR fully resolves the issue scope
+- no additional linked follow-up remains required for the same issue
+
+Keep the issue item out of **Done** yet when:
+- another required follow-up PR is still open
+- the merge only landed a prerequisite policy/docs change
+- Clay/Boe review still expects another explicit review item to land before the issue is complete
+
+In all cases, confirm the issue item's `Evidence` field includes the final durable reference used to justify the new state.
+
+## Quick decision table
+
+| Situation | Merge first | Follow-up action |
+| --- | --- | --- |
+| Two unrelated green docs PRs | Either; prefer smaller/lower-risk first | Update each controlling issue normally |
+| Docs/process PR + dependent automation PR | Docs/process PR | Rebase/retarget automation PR if needed |
+| PR B stacked on PR A | PR A | Retarget/rebase PR B onto `main`, then re-check CI |
+| Duplicate issue + PR items in Project #1 | Use issue item as canonical | Keep PR URL in issue `Evidence`; avoid PR-item-led triage |
+| Merge lands but issue still has required follow-up | Do not mark issue done yet | Keep status aligned with remaining work |
+
+## Anti-patterns to avoid
+
+Do **not**:
+- merge purely by oldest-review timestamp when dependencies exist
+- use a duplicate PR Project item as the canonical review queue record for normal issue-driven work
+- leave stacked follow-up PRs pointing at merged branches indefinitely
+- mark an issue `Done` before its last required follow-up merges
+- forget to update `Evidence` after a merge, leaving maintainers without the durable link trail


### PR DESCRIPTION
## Summary
- add a maintainer-facing Project #1 merge-order checklist for multi-item review queues
- define the default merge order for dependency bases, rule-setting docs/process PRs, independent low-risk items, and stacked follow-ups
- clarify how the issue-first review convention affects merge sequencing and post-merge Evidence/Status updates
- link the new checklist from the Project #1 field conventions, CONTRIBUTING guide, and README quick links

## Linked Issue
- Closes #266

## 2-stage review confirmation
### Stage 1 — Self-review (author, xhigh reasoning)
- [x] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).
- [x] I confirmed the implementation satisfies the linked issue scope.

### Stage 2 — Final review (Boe)
- [x] Final review requested from **Boe**.

## Validation evidence
### Lint
```bash
# docs-only change; not run
npm run lint
```

### Tests
```bash
# docs-only change; not run
npm test
```

### Build
```bash
# docs-only change; not run
npm run build
```

### Lightweight relevant validation
```bash
git diff --check
# no output

node - <<'NODE'
const fs = require('fs');
const path = require('path');
const files = [
  'docs/ops/project-1-review-merge-order-checklist.md',
  'docs/ops/project-1-field-conventions.md',
  'CONTRIBUTING.md',
  'README.md',
];
for (const file of files) {
  const text = fs.readFileSync(file, 'utf8');
  const links = [...text.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)]
    .map(m => m[1])
    .filter(h => !/^(https?:|mailto:|#)/.test(h));
  for (const link of links) {
    const clean = link.split('#')[0];
    const resolved = path.normalize(path.join(path.dirname(file), clean || '.'));
    if (!fs.existsSync(resolved)) throw new Error(`${file}: broken relative link ${link} -> ${resolved}`);
  }
  console.log(`${file}: relative-links-ok (${links.length})`);
}
NODE
# docs/ops/project-1-review-merge-order-checklist.md: relative-links-ok (2)
# docs/ops/project-1-field-conventions.md: relative-links-ok (1)
# CONTRIBUTING.md: relative-links-ok (5)
# README.md: relative-links-ok (26)
```

## UI changes
- [x] N/A (no UI changes)
- [ ] Screenshots/GIF attached below

## Risks / edge cases
- This is process documentation only; it does not automate merge-order enforcement.
- The checklist intentionally stays compatible with the issue-first Project #1 convention without requiring currently open follow-up docs PRs to merge first.
- Maintainers still need judgment for ambiguous dependency chains or intentionally standalone PR items.

## Additional notes
- The checklist explicitly captures the current stacked example mentioned in the issue (`#261 -> #263`) as the merge-order model.
- Scope is limited to review sequencing and post-merge Project hygiene for Project #1 items.
