### PR TITLE
docs: add Project #1 review-queue daily-loop SOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ npm run build
 - Project #1 field conventions: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
 - Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)
 - Branch protection runbook (require **Verify (core)** on `main`): [`docs/ops/branch-protection.md`](./docs/ops/branch-protection.md)
+- Project #1 CI triage quick guide: [`docs/ops/project-1-ci-triage-quick-guide.md`](./docs/ops/project-1-ci-triage-quick-guide.md)
 
 Project #1 status sync workflows require **GitHub Projects v2 auth** (separate token).
 Tracking issue: [#80](https://github.com/Clay-Agency/novel-task-tracker/issues/80)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ npm run build
 - Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)
 - Branch protection runbook (require **Verify (core)** on `main`): [`docs/ops/branch-protection.md`](./docs/ops/branch-protection.md)
 - Project #1 CI triage quick guide: [`docs/ops/project-1-ci-triage-quick-guide.md`](./docs/ops/project-1-ci-triage-quick-guide.md)
+- Project #1 review-queue daily loop SOP: [`docs/ops/project-1-review-queue-daily-loop.md`](./docs/ops/project-1-review-queue-daily-loop.md)
 
 Project #1 status sync workflows require **GitHub Projects v2 auth** (separate token).
 Tracking issue: [#80](https://github.com/Clay-Agency/novel-task-tracker/issues/80)

--- a/docs/ops/ci-maintenance-runbook.md
+++ b/docs/ops/ci-maintenance-runbook.md
@@ -8,6 +8,7 @@ This runbook covers the scheduled CI maintenance workflow used to catch regressi
 
 ## Related runbooks
 - Projects v2 auth (GitHub App) setup + troubleshooting: [`docs/ops/projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
+- Project #1 review-item triage shortcut: [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md)
 
 ## Trigger modes
 The workflow runs in two ways:

--- a/docs/ops/project-1-ci-triage-quick-guide.md
+++ b/docs/ops/project-1-ci-triage-quick-guide.md
@@ -1,0 +1,94 @@
+# Project #1 CI triage quick guide (Issue #272)
+
+Use this when clearing **Project #1** review items and you need a fast, repeatable way to read PR checks.
+This guide is intentionally narrow: it tells maintainers which PR checks are **merge blockers** vs **advisory signals** for the common review-item types.
+
+For deeper failure handling and known GitHub Actions flakes, use the canonical runbook:
+- [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md)
+
+## 1) First sort the PR into one of two buckets
+
+### Docs / process PR
+Use this bucket when the PR mainly changes:
+- `README.md`
+- `docs/**`
+- issue / PR templates
+- project-process text with no app/runtime behavior change
+
+### Automation / code PR
+Use this bucket when the PR changes:
+- `src/**`
+- test code or Playwright/Vitest config
+- `package.json` / `package-lock.json`
+- `.github/workflows/**`
+- build, lint, or TypeScript config
+
+If a PR touches both docs and automation/code surfaces, treat it as **automation / code**.
+
+## 2) Check matrix: required vs advisory
+
+| Check | What it covers | Docs / process PR | Automation / code PR |
+| --- | --- | --- | --- |
+| **Verify (core) / npm run verify:core** | Workflow syntax, lint, typecheck, unit tests, build | **Required** | **Required** |
+| **Markdown link check / check-markdown-links** | Internal link validity in `README.md` and `docs/**` | **Required** when the PR changes docs/README links or file paths; otherwise advisory | **Advisory** unless the PR also changes docs/README links |
+| **CI / test-and-lint** | Lint, typecheck, unit tests, Playwright smoke | **Advisory** for docs/process-only work | **Required** |
+| **Scheduled CI Maintenance** | Weekly maintenance workflow on `main` / manual dispatch | Not a PR merge gate | Not a PR merge gate |
+
+## 3) Fast interpretation rules
+
+### Safe-to-merge pattern: docs / process PR
+Normally safe to merge when:
+1. **Verify (core)** is green.
+2. **Markdown link check** is green if the PR changed docs links, filenames, or relative references.
+3. **CI** is either green or clearly irrelevant to the docs-only diff.
+
+Stop and escalate instead of guessing when a docs/process PR unexpectedly changes dependency-sensitive or automation-sensitive files.
+
+### Safe-to-merge pattern: automation / code PR
+Normally safe to merge when:
+1. **Verify (core)** is green.
+2. **CI** is green.
+3. Any additional check failures are understood and non-blocking.
+
+Treat red **CI** on automation/code PRs as a real merge blocker unless you can prove it is a transient GitHub Actions problem.
+
+## 4) Quick failure meanings
+
+- **Verify (core) red**
+  - Treat as a merge blocker for every PR type.
+  - This is the branch-protection baseline documented in [`branch-protection.md`](./branch-protection.md).
+
+- **Markdown link check red**
+  - Usually means a broken relative link, renamed file, or missing docs target.
+  - For docs/process review items, treat it as blocking if the PR touched `README.md` or `docs/**` navigation.
+
+- **CI red on docs/process PR**
+  - First confirm the diff is truly docs/process only.
+  - If yes, treat it as advisory and note the result in review comments if needed.
+  - If no, reclassify the PR as automation/code and require CI green.
+
+- **CI red on automation/code PR**
+  - Treat as blocking.
+  - Use [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md) for build/test/workflow triage.
+
+## 5) Known GitHub Actions UI/API flake
+
+If a PR or `gh pr checks` briefly shows **no checks reported** right after open/push:
+- wait about 15–60 seconds,
+- retry once,
+- confirm runs exist before assuming triggers are broken.
+
+Reference: known flake notes in [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md).
+
+## 6) Review-clearing order hint
+
+When clearing a queue, do the checks in this order:
+1. Confirm the **issue item** is the canonical Project #1 record.
+2. Confirm the PR is not stacked behind an unmerged prerequisite.
+3. Classify the PR as **docs/process** or **automation/code**.
+4. Read only the checks that matter for that bucket.
+5. Merge only after the required checks for that bucket are green.
+
+Related queue-clearing work in progress:
+- Issue #270 — Project #1 review-clearing quick-start: https://github.com/Clay-Agency/novel-task-tracker/issues/270
+- Issue #266 — merge-order checklist follow-up: https://github.com/Clay-Agency/novel-task-tracker/issues/266

--- a/docs/ops/project-1-review-queue-daily-loop.md
+++ b/docs/ops/project-1-review-queue-daily-loop.md
@@ -1,0 +1,127 @@
+# Project #1 review-queue daily loop SOP (Issue #274)
+
+Use this SOP when doing one focused maintainer pass through **Clay-Agency org Project #1** review items.
+It is intentionally compact: follow this start-to-finish flow, and use the linked runbooks only when you need detail.
+
+## Goal
+
+In one session:
+1. scan the current **Review** queue,
+2. identify mergeable items,
+3. avoid merging PRs out of dependency order,
+4. merge items whose required checks are green,
+5. confirm post-merge Project state is correct.
+
+## Before you start
+
+Have these references open:
+- Project field meanings: [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+- CI interpretation for review items: [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md)
+- Branch protection baseline: [`branch-protection.md`](./branch-protection.md)
+- Project status sync behavior: [`project-status-sync.md`](./project-status-sync.md)
+- Projects v2 auth/troubleshooting: [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
+- Deep CI failure handling: [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md)
+
+## Daily loop
+
+### 1) Scan the Review queue
+
+Start with Project #1 items whose **Status** is `Review`.
+For each item, identify the canonical links:
+- issue link
+- open PR link
+- latest CI/check context
+
+If an item is in `Review` but has no open PR, remove it from the merge pass and correct the Project state before continuing.
+
+### 2) Confirm the issue is the canonical Project record
+
+Use the **issue** as the source-of-truth Project item whenever possible.
+Before reviewing the PR, confirm the issue still reflects the work accurately:
+- title/scope still matches the PR,
+- **Owner agent** is still correct,
+- **Needs decision** is not blocking,
+- **Evidence** includes the current PR link when applicable.
+
+Field meanings and expectations live in [`project-1-field-conventions.md`](./project-1-field-conventions.md).
+
+### 3) Check dependency / merge order before reading CI
+
+Do not merge a PR just because checks are green.
+First confirm it is not blocked behind another open PR.
+
+Look for signs of dependency such as:
+- PR body or issue notes referencing a prerequisite PR/issue,
+- stacked branch naming or “based on” language,
+- review comments noting “merge after <other PR>”,
+- failing/irrelevant diffs caused by a missing upstream merge.
+
+If the PR depends on another open PR:
+- leave it in the queue,
+- merge the prerequisite first,
+- then refresh checks/rebase status before returning.
+
+### 4) Classify the PR and read only the checks that matter
+
+Use [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md) to bucket the PR:
+- **docs / process PR**, or
+- **automation / code PR**.
+
+Then apply the required checks for that bucket:
+- **Always require** `Verify (core)`.
+- Require **Markdown link check** when docs/README links or file paths changed.
+- Require full **CI** for automation/code PRs.
+- Treat scheduled maintenance workflows as non-gating.
+
+If a required check is red, stop and triage instead of guessing.
+Use [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md) when the failure needs deeper handling.
+
+### 5) Merge the ready PRs
+
+A PR is normally ready to merge when:
+- scope still matches the issue,
+- it is not blocked by dependency order,
+- required checks for its bucket are green,
+- there is no open decision preventing merge.
+
+Merge in dependency order, oldest prerequisite first.
+After each merge, refresh the queue before acting on the next item.
+A merge can change which downstream items are now ready.
+
+### 6) Confirm post-merge Project updates
+
+After merge, confirm the Project item moved to the expected end state.
+The status-sync workflow is supposed to reconcile merged work, but maintainers should still verify the result.
+
+Check that:
+- the issue/PR no longer needs active review handling,
+- **Status** moved appropriately toward `Done`,
+- **Evidence** contains the merged PR reference,
+- any stale `Needs decision=True` flag was cleared if no longer applicable.
+
+If the automatic Project update did not happen:
+- review [`project-status-sync.md`](./project-status-sync.md),
+- check Projects auth/troubleshooting in [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md),
+- then correct the Project item manually if needed.
+
+## Fast stop conditions
+
+Pause the loop and escalate instead of improvising when:
+- the Project item and PR scope no longer match,
+- a dependency chain is unclear,
+- required checks are failing for unclear reasons,
+- branch protection behavior differs from the runbook,
+- Project automation did not update and the cause is not obvious,
+- a Clay decision is required before merge.
+
+## One-pass maintainer checklist
+
+Use this as the compact session checklist:
+1. Open Project #1 `Review` items.
+2. Verify each item has the right issue + PR pairing.
+3. Check for prerequisite / stacked PR dependencies.
+4. Classify each PR by review bucket.
+5. Read only the required checks for that bucket.
+6. Merge only the items that are truly ready.
+7. Verify post-merge Project/Evidence state.
+8. Escalate unclear blockers instead of guessing.


### PR DESCRIPTION
## Summary
- add a compact Project #1 review-queue daily-loop SOP for one maintainer review-clearing session
- cover queue scan, issue/PR pairing, dependency/merge-order check, CI check, merge step, and post-merge Project verification
- link the new SOP from the README ops quick links

## Linked Issue
- Closes #274

## 2-stage review confirmation
### Stage 1 — Self-review (author, xhigh reasoning)
- [x] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).
- [x] I confirmed the implementation satisfies the linked issue scope.

### Stage 2 — Final review (Boe)
- [x] Final review requested from **Boe**.

## Validation evidence
### Relevant docs validation
```bash
git diff --check
# clean

python3 - <<'PY'
import re
from pathlib import Path
files = [Path('README.md'), Path('docs/ops/project-1-review-queue-daily-loop.md')]
pat = re.compile(r'\[[^\]]+\]\(([^)]+)\)')
errors=[]
for f in files:
    text=f.read_text()
    for target in pat.findall(text):
        if target.startswith(('http://','https://','mailto:','#')):
            continue
        target=target.split('#',1)[0]
        path=(f.parent/target).resolve()
        if not path.exists():
            errors.append(f'{f}: missing -> {target}')
if errors:
    print('\n'.join(errors))
    raise SystemExit(1)
print('OK relative markdown links for changed docs')
PY
# OK relative markdown links for changed docs
```

### Notes
```bash
npm run docs:links
# failed locally because lychee is not installed in this environment:
# sh: lychee: command not found
```

## UI changes
- [x] N/A (no UI changes)
- [ ] Screenshots/GIF attached below

## Risks / edge cases
- SOP depends on current Project #1 field names and current review workflow assumptions; if Project fields or queue conventions change later, the doc will need refresh.
- Local full markdown-link tooling was unavailable, so validation used a targeted fallback for changed-file relative links only.

## Additional notes
- This is docs/ops-only scope; no app/runtime behavior changed.
