### PR TITLE
docs: cross-link Project #1 maintainer runbooks

### DIFF
--- a/docs/ops/branch-protection.md
+++ b/docs/ops/branch-protection.md
@@ -2,6 +2,8 @@
 
 Goal: require the **Verify (core)** GitHub Actions check to pass before merging to `main`.
 
+Related Project #1 maintainer docs: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
+
 ## Enable (GitHub UI)
 1. Open the repo on GitHub.
 2. Go to **Settings** → **Branches**.

--- a/docs/ops/ci-maintenance-runbook.md
+++ b/docs/ops/ci-maintenance-runbook.md
@@ -7,6 +7,7 @@ This runbook covers the scheduled CI maintenance workflow used to catch regressi
 - Workflow name in GitHub Actions: **Scheduled CI Maintenance**
 
 ## Related runbooks
+- Project #1 maintainer doc hub: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
 - Projects v2 auth (GitHub App) setup + troubleshooting: [`docs/ops/projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
 
 ## Trigger modes

--- a/docs/ops/clay-admin-quickstart.md
+++ b/docs/ops/clay-admin-quickstart.md
@@ -5,6 +5,8 @@ This is a **GitHub-first**, low-friction checklist for Clay (org admin) to unblo
 If you need full details (copy/paste commands, troubleshooting, rotation/incident response), use the canonical runbook:
 - **Projects v2 auth runbook**: [`docs/ops/projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
 
+For the broader Project #1 maintainer doc set and navigation, see [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md).
+
 ## Operational guardrails (recommended)
 
 - **Protect `main` (required check gate)**: [`docs/ops/branch-protection.md`](./branch-protection.md)

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -2,6 +2,8 @@
 
 As observed **2026-03-06** (fields/options may evolve).
 
+Project #1 maintainer navigation hub: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
+
 ## Status (single select)
 
 Allowed values:

--- a/docs/ops/project-1-maintainer-runbook-index.md
+++ b/docs/ops/project-1-maintainer-runbook-index.md
@@ -1,0 +1,50 @@
+# Project #1 maintainer runbook index (Issue #276)
+
+Use this page as the navigation hub for **Clay-Agency org Project #1** maintainer operations.
+It does not replace the detailed runbooks; it points maintainers to the right doc for the task at hand.
+
+## Current maintainer runbook set
+
+### Core Project semantics
+- [`project-1-field-conventions.md`](./project-1-field-conventions.md) — canonical meaning for Project #1 fields, status values, owner expectations, and Evidence usage.
+
+### Project automation and post-merge state
+- [`project-status-sync.md`](./project-status-sync.md) — what the status-sync workflow updates and when it runs.
+- [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md) — GitHub App setup, validation, and troubleshooting when Project automation cannot read/write Project #1.
+- [`projects-v2-auth.md`](./projects-v2-auth.md) — compact auth/setup reference.
+- [`clay-admin-quickstart.md`](./clay-admin-quickstart.md) — fast admin checklist for Clay when project automation needs to be enabled or repaired.
+
+### Merge / review guardrails
+- [`branch-protection.md`](./branch-protection.md) — required PR check and approval baseline for merging to `main`.
+- [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md) — deeper CI failure handling, workflow flakes, and ownership/rotation guidance.
+- [`project-1-workflow-auto-add-filter.md`](./project-1-workflow-auto-add-filter.md) — how to keep Project #1 auto-add rules from pulling in automation/meta issues.
+
+## Recommended reading order for common maintainer work
+
+### Verifying Project state and field usage
+1. [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+2. [`project-status-sync.md`](./project-status-sync.md)
+3. [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
+
+### Reviewing whether a merge path is healthy
+1. [`branch-protection.md`](./branch-protection.md)
+2. [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md)
+3. [`project-status-sync.md`](./project-status-sync.md)
+
+### Repairing Project automation/setup
+1. [`clay-admin-quickstart.md`](./clay-admin-quickstart.md)
+2. [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
+3. [`projects-v2-auth.md`](./projects-v2-auth.md)
+
+## Related follow-ups still tracked in issues
+
+Some review-queue-specific maintainer procedures are still tracked as open follow-ups rather than merged standalone docs:
+- Issue #258 — duplicate review-item cleanup
+- Issue #264 — stacked follow-up PR handling
+- Issue #266 — merge-order checklist
+- Issue #268 — maintainer runbook index/orientation follow-up
+- Issue #270 — review-clearing quick-start
+- Issue #272 — CI triage quick guide for review items
+- Issue #274 — review-queue daily-loop SOP
+
+This index intentionally links only to docs that are currently present in the repo so navigation stays accurate.

--- a/docs/ops/project-1-workflow-auto-add-filter.md
+++ b/docs/ops/project-1-workflow-auto-add-filter.md
@@ -2,6 +2,8 @@
 
 Use this when Project #1 is auto-adding “meta”/automation issues (for context, see #169).
 
+Related Project #1 maintainer docs: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
+
 ## Goal
 Update the Project #1 **Workflows → Auto-add** filter to exclude issues labeled `automation` by appending `-label:automation`.
 

--- a/docs/ops/project-status-sync.md
+++ b/docs/ops/project-status-sync.md
@@ -12,6 +12,8 @@ It syncs **Clay-Agency org Project #1** (Projects v2 / `ProjectV2`) fields when:
 
 Detailed setup (GitHub App least-privilege, PAT fallback, troubleshooting): [`docs/ops/projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md).
 
+For the broader Project #1 maintainer runbook set, start from [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md).
+
 GitHub’s built-in Actions token (`secrets.GITHUB_TOKEN`) **cannot** update **organization Projects v2** via GraphQL.
 
 You must provide **one** of the following:

--- a/docs/ops/projects-v2-auth-runbook.md
+++ b/docs/ops/projects-v2-auth-runbook.md
@@ -1,5 +1,7 @@
 # Runbook — Projects v2 auth (GitHub App) for Clay-Agency org Project #1
 
+Related maintainer docs: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
+
 This repo has GitHub Actions automation that **reads + updates** the Clay-Agency **organization Project (Projects v2 / `ProjectV2`)** via the **GraphQL API**.
 
 GitHub’s built-in Actions token (`GITHUB_TOKEN`) **cannot** mutate **organization Projects v2**, so we use a **GitHub App installation token** minted at runtime.


### PR DESCRIPTION
## Summary
- add a Project #1 maintainer runbook index as a lightweight navigation hub
- cross-link the existing Project #1 ops/runbook docs back to that index
- explicitly note the still-open review-queue follow-up docs so navigation stays accurate to the current repo state

## Validation
- local offline relative-link validation script for the changed Markdown files
- attempted `npm run docs:links`, but the local `lychee` binary is not installed in this environment

Closes #276
