### PR TITLE
docs: codify Project #1 review queue dedupe convention

### DIFF
--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -65,3 +65,11 @@ Conventions:
   - `Decision record: docs/decisions/DR-XXXX-...md`
   - `QA evidence: <url or docs/qa/...#anchor>`
 - When moving work to **Review** or **Done**, make sure the Evidence field includes the relevant PR/merge reference.
+
+## Review queue de-duplication convention
+
+Conventions:
+- For normal issue-driven work, keep the **issue item** as the canonical Project #1 tracking record.
+- If the issue item is already in **Review** and its `Evidence` field links the active PR, remove the redundant **PR item** from Project #1 instead of carrying both issue + PR review records.
+- Keep a PR item only when it represents a genuinely separate thing to review (for example, standalone PR-only work or a temporary maintainer workflow that is not already tracked by an issue item).
+- During cleanup passes, verify the paired issue still has the correct PR URL in `Evidence` before deleting the duplicate PR item.


### PR DESCRIPTION
## Summary
- codify the issue-first Project #1 review-queue convention in `docs/ops/project-1-field-conventions.md`
- document when a redundant PR item should be removed versus retained
- complete the second cleanup pass by removing the duplicate PR Review items from Project #1 for #259/#261/#263/#265/#267/#269/#271/#273/#275/#277

## Validation
- `git diff --check`
- `gh project item-list 1 --owner Clay-Agency --limit 300 --format json | jq -r '[.items[] | select(.status=="Review" and .content.type=="PullRequest")] | length'` → `0`
- `npm run docs:links` could not run here because `lychee` is not installed locally, and Docker fallback was unavailable in this environment

Closes #278
