### PR TITLE
docs: add Project #1 blocker-vs-ready triage guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 
 - [Projects v2 auth runbook](./docs/ops/projects-v2-auth-runbook.md): Use when configuring or debugging GitHub Actions auth for workflows that read/update the Clay-Agency org Project #1 (GraphQL `ProjectV2`).
 - [Project #1 field conventions](./docs/ops/project-1-field-conventions.md): Use when triaging work on the Project #1 board or building automation that writes project fields (Status, Priority, Owner agent, Needs decision, Evidence).
+- [Project #1 maintainer triage guide](./docs/ops/project-1-triage-guide.md): Use during cleanup/review passes to distinguish Clay-decision blockers, dependency blockers, and merge-ready review items.
 
 ## Markdown link check
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ npm run build
 ### Quick links
 - Projects v2 auth runbook: [`docs/ops/projects-v2-auth-runbook.md`](./docs/ops/projects-v2-auth-runbook.md)
 - Project #1 field conventions: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
+- Project #1 maintainer triage guide: [`docs/ops/project-1-triage-guide.md`](./docs/ops/project-1-triage-guide.md)
 - Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)
 - Branch protection runbook (require **Verify (core)** on `main`): [`docs/ops/branch-protection.md`](./docs/ops/branch-protection.md)
 

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -18,6 +18,8 @@ Conventions:
 - **Review**: implementation is done and waiting on review/merge (typically there is an open PR).
 - **Done**: work is complete (merged/closed) and no further action is expected.
 
+Maintainer blocker-vs-ready triage guide: [`docs/ops/project-1-triage-guide.md`](./project-1-triage-guide.md)
+
 ## Priority (single select)
 
 Allowed values:

--- a/docs/ops/project-1-triage-guide.md
+++ b/docs/ops/project-1-triage-guide.md
@@ -1,0 +1,91 @@
+# Project #1 maintainer triage guide — blocker vs ready (Issue #280)
+
+Use this during Project #1 cleanup/review passes when an item looks active but it is not obvious whether it should stay in **Review**, move to **Blocked**, or return to **In progress**.
+
+This guide is intentionally short. Reuse the linked runbooks for the detailed mechanics.
+
+## Fast branching rule
+
+Ask these in order:
+
+1. **Is implementation complete and is the next maintainer action review/merge?**
+   - **Yes** → keep/move item to **Review**.
+2. **Is progress blocked by a Clay decision?**
+   - **Yes** → move item to **Blocked** and set `Needs decision=True`.
+3. **Is progress blocked by some other dependency?**
+   - **Yes** → move item to **Blocked** and keep `Needs decision=False` unless Clay input is explicitly required.
+4. **Otherwise**
+   - keep/move item to **In progress** (work still needed before review).
+
+## Triage outcomes
+
+| Situation | Project `Status` | `Needs decision` | Maintainer action |
+| --- | --- | --- | --- |
+| Implementation complete; waiting on review/merge | `Review` | `False` | Make sure `Evidence` links the active PR/CI and request final review. |
+| Blocked on explicit Clay decision (policy, direction, trade-off) | `Blocked` | `True` | Add/remove the repo `needs-decision` label as needed, state the decision question + options in the issue, and link the decision brief/evidence. |
+| Blocked on external dependency but **not** a Clay decision (access, upstream fix, reviewer identity constraint, waiting on another repo/system) | `Blocked` | `False` | Record the dependency clearly in the issue and `Evidence`, plus the next trigger/checkpoint. |
+| Work is still being implemented or revised before review | `In progress` | `False` (usually) | Leave with current owner and continue execution work. |
+
+## How to classify common Project #1 cases
+
+### 1) Clay-decision blocker
+Use this when the work cannot move until Clay chooses a direction.
+
+Examples:
+- **#80** — auth approach decision for Project #1 automation (**GitHub App vs PAT**)
+- **#126** — priority taxonomy decision (**add P3 vs collapse into P2**)
+
+Maintainer checklist:
+- Set Project `Status` to **Blocked**.
+- Set Project `Needs decision` to **True**.
+- Apply repo label `needs-decision`.
+- Ensure the issue contains:
+  - the decision question,
+  - 1–3 options,
+  - recommended default if helpful,
+  - links to supporting evidence/runbooks.
+- Link the durable doc instead of rewriting the whole context:
+  - [`docs/ops/open-decisions.md`](./open-decisions.md)
+  - [`docs/ops/needs-decision-snapshot.md`](./needs-decision-snapshot.md)
+
+## 2) Dependency blocker (not decision-bound)
+Use this when the work is blocked, but the blocker is an external dependency rather than a Clay decision.
+
+Examples:
+- waiting on upstream access/configuration
+- waiting on another PR/repo/workflow
+- waiting on a reviewer identity or permissions constraint to be resolved
+
+Maintainer checklist:
+- Set Project `Status` to **Blocked**.
+- Keep Project `Needs decision` as **False** unless there is an actual Clay decision request.
+- Do **not** apply `needs-decision` just because the item is stalled.
+- In the issue, write the blocker in one sentence and state what event unblocks it.
+- Put the concrete evidence link in the Project `Evidence` field.
+
+## 3) Merge-ready review item
+Use this when implementation is done and the next meaningful step is review/merge rather than more execution.
+
+Maintainer checklist:
+- Set Project `Status` to **Review**.
+- Keep Project `Needs decision` at **False**.
+- Ensure Project `Evidence` includes, at minimum:
+  - `PR: <url>`
+  - `CI: <url>` when relevant
+- Follow the review flow in [`CONTRIBUTING.md`](../../CONTRIBUTING.md#2-stage-review-process-required).
+- Apply the de-duplication rule from [`docs/ops/project-1-field-conventions.md`](./project-1-field-conventions.md): keep the **issue item** as canonical when it already tracks the active PR.
+
+## Short maintainer checklist for cleanup passes
+
+When triaging a Project #1 item, confirm:
+- Is the next action **review/merge**, **decision**, **dependency resolution**, or **more implementation**?
+- Does `Status` match that next action?
+- Does `Needs decision` reflect an actual Clay decision blocker, not just general delay?
+- Does `Evidence` contain the single most useful link for the current state?
+- If the item is in **Review**, is there a redundant PR item that should be removed?
+
+## Related docs
+
+- Field definitions and evidence conventions: [`docs/ops/project-1-field-conventions.md`](./project-1-field-conventions.md)
+- Needs-decision process: [`CONTRIBUTING.md#needs-decision-convention`](../../CONTRIBUTING.md#needs-decision-convention)
+- Open decision checklist: [`docs/ops/open-decisions.md`](./open-decisions.md)


### PR DESCRIPTION
Closes #280

## Summary
- add a short maintainer triage guide for Project #1 blocker-vs-ready cleanup passes
- distinguish Clay-decision blockers, dependency blockers, and merge-ready review items
- cross-link the new guide from the existing Project #1 docs instead of duplicating policy text

## Files
- `docs/ops/project-1-triage-guide.md`
- `docs/ops/project-1-field-conventions.md`
- `CONTRIBUTING.md`
- `README.md`

## Validation
- `lychee` not installed in local environment, so full `npm run docs:links` was not run
- targeted internal-link validation passed via local Node script across changed docs

## Risks / notes
- docs-only change; no product/runtime behavior changed
- guide intentionally stays brief and points back to the canonical field/decision docs

## 2-stage review confirmation
### Stage 1 — Self-review (author, xhigh reasoning)
- [x] I completed self-review using xhigh reasoning (requirements, assumptions, edge cases, failure paths).
- [x] I verified the change stays scoped to issue #280.

### Stage 2 — Final review (Boe)
- [ ] Final review requested from **Boe**.
