### PR TITLE
docs: add Project #1 maintainer lifecycle map

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,11 @@
 ### Stage 2 — Final review (Boe)
 - [ ] Final review requested from **Boe**.
 
+## Draft / stack context (only if applicable)
+- [ ] N/A
+- Draft PR:
+- Blocked by / ready after:
+
 ## Validation evidence
 ### Lint
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,25 +68,19 @@ CI validates **internal/relative** links in `README.md` and `docs/**` (external 
 Run locally:
 
 ```bash
-# Option A: run via npm (requires lychee installed)
-#   brew install lychee
-#   # or: cargo install lychee
-
+# Preferred: auto-detect a runnable checker.
+# - Uses local lychee when installed.
+# - Falls back to Docker when the daemon is reachable.
+# - Prints exact setup steps if neither path is available.
 npm run docs:links
 
-# Option B: Docker (no local lychee install required)
-#   Optional readiness check (daemon reachable):
-#   docker info >/dev/null
-
+# Force the Docker path (useful after starting Docker/OrbStack)
+# docker info >/dev/null
 npm run docs:links:docker
 
-# (Equivalent direct command)
-# docker run --rm -v "$(pwd)":/workdir -w /workdir \
-#   ghcr.io/lycheeverse/lychee:latest \
-#   --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
-
-# If you see "Cannot connect to the Docker daemon", start Docker/OrbStack first,
-# then rerun the command.
+# Optional: install lychee for the local path
+# brew install lychee
+# # or: cargo install lychee
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 
 - [Projects v2 auth runbook](./docs/ops/projects-v2-auth-runbook.md): Use when configuring or debugging GitHub Actions auth for workflows that read/update the Clay-Agency org Project #1 (GraphQL `ProjectV2`).
 - [Project #1 field conventions](./docs/ops/project-1-field-conventions.md): Use when triaging work on the Project #1 board or building automation that writes project fields (Status, Priority, Owner agent, Needs decision, Evidence).
+- [Project #1 maintainer triage guide](./docs/ops/project-1-triage-guide.md): Use during cleanup/review passes to distinguish Clay-decision blockers, dependency blockers, and merge-ready review items.
 
 ## Markdown link check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,11 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 
 ## Ops runbooks (Project #1 automation)
 
+- [Project #1 maintainer lifecycle map](./docs/ops/project-1-maintainer-lifecycle-map.md): Use as the compact navigation layer across triage, review, merge, and post-merge hygiene.
 - [Projects v2 auth runbook](./docs/ops/projects-v2-auth-runbook.md): Use when configuring or debugging GitHub Actions auth for workflows that read/update the Clay-Agency org Project #1 (GraphQL `ProjectV2`).
 - [Project #1 field conventions](./docs/ops/project-1-field-conventions.md): Use when triaging work on the Project #1 board or building automation that writes project fields (Status, Priority, Owner agent, Needs decision, Evidence).
 - [Project #1 maintainer triage guide](./docs/ops/project-1-triage-guide.md): Use during cleanup/review passes to distinguish Clay-decision blockers, dependency blockers, and merge-ready review items.
+- [Project #1 post-merge hygiene checklist](./docs/ops/project-1-post-merge-hygiene-checklist.md): Use right after merge/close to verify final Status/Evidence, remove redundant PR items, and decide whether a one-off note or durable doc update is needed.
 
 ## Markdown link check
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ npm run lint
 npm run typecheck
 npm run test
 npm run e2e
+npm run docs:links
+npm run verify:quick
+npm run verify:core
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ npm run build
 ## Ops / Automation
 
 ### Quick links
+- Project #1 review-clearing quick start: [`docs/ops/project-1-review-clearing-quick-start.md`](./docs/ops/project-1-review-clearing-quick-start.md)
 - Projects v2 auth runbook: [`docs/ops/projects-v2-auth-runbook.md`](./docs/ops/projects-v2-auth-runbook.md)
 - Project #1 field conventions: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
 - Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ npm run build
 - Project #1 review-clearing quick start: [`docs/ops/project-1-review-clearing-quick-start.md`](./docs/ops/project-1-review-clearing-quick-start.md)
 - Projects v2 auth runbook: [`docs/ops/projects-v2-auth-runbook.md`](./docs/ops/projects-v2-auth-runbook.md)
 - Project #1 field conventions: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
+- Project #1 maintainer triage guide: [`docs/ops/project-1-triage-guide.md`](./docs/ops/project-1-triage-guide.md)
 - Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)
 - Branch protection runbook (require **Verify (core)** on `main`): [`docs/ops/branch-protection.md`](./docs/ops/branch-protection.md)
 - Project #1 CI triage quick guide: [`docs/ops/project-1-ci-triage-quick-guide.md`](./docs/ops/project-1-ci-triage-quick-guide.md)

--- a/README.md
+++ b/README.md
@@ -59,14 +59,16 @@ npm run build
 ## Ops / Automation
 
 ### Quick links
+- Project #1 maintainer lifecycle map: [`docs/ops/project-1-maintainer-lifecycle-map.md`](./docs/ops/project-1-maintainer-lifecycle-map.md)
 - Project #1 review-clearing quick start: [`docs/ops/project-1-review-clearing-quick-start.md`](./docs/ops/project-1-review-clearing-quick-start.md)
-- Projects v2 auth runbook: [`docs/ops/projects-v2-auth-runbook.md`](./docs/ops/projects-v2-auth-runbook.md)
-- Project #1 field conventions: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
 - Project #1 maintainer triage guide: [`docs/ops/project-1-triage-guide.md`](./docs/ops/project-1-triage-guide.md)
-- Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)
-- Branch protection runbook (require **Verify (core)** on `main`): [`docs/ops/branch-protection.md`](./docs/ops/branch-protection.md)
 - Project #1 CI triage quick guide: [`docs/ops/project-1-ci-triage-quick-guide.md`](./docs/ops/project-1-ci-triage-quick-guide.md)
 - Project #1 review-queue daily loop SOP: [`docs/ops/project-1-review-queue-daily-loop.md`](./docs/ops/project-1-review-queue-daily-loop.md)
+- Project #1 post-merge hygiene checklist: [`docs/ops/project-1-post-merge-hygiene-checklist.md`](./docs/ops/project-1-post-merge-hygiene-checklist.md)
+- Project #1 field conventions: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
+- Projects v2 auth runbook: [`docs/ops/projects-v2-auth-runbook.md`](./docs/ops/projects-v2-auth-runbook.md)
+- Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)
+- Branch protection runbook (require **Verify (core)** on `main`): [`docs/ops/branch-protection.md`](./docs/ops/branch-protection.md)
 
 Project #1 status sync workflows require **GitHub Projects v2 auth** (separate token).
 Tracking issue: [#80](https://github.com/Clay-Agency/novel-task-tracker/issues/80)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ npm run build
 - Project #1 field conventions: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
 - Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)
 - Branch protection runbook (require **Verify (core)** on `main`): [`docs/ops/branch-protection.md`](./docs/ops/branch-protection.md)
+- Project #1 CI triage quick guide: [`docs/ops/project-1-ci-triage-quick-guide.md`](./docs/ops/project-1-ci-triage-quick-guide.md)
 
 Project #1 status sync workflows require **GitHub Projects v2 auth** (separate token).
 Tracking issue: [#80](https://github.com/Clay-Agency/novel-task-tracker/issues/80)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ npm run build
 - Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)
 - Branch protection runbook (require **Verify (core)** on `main`): [`docs/ops/branch-protection.md`](./docs/ops/branch-protection.md)
 - Project #1 CI triage quick guide: [`docs/ops/project-1-ci-triage-quick-guide.md`](./docs/ops/project-1-ci-triage-quick-guide.md)
+- Project #1 review-queue daily loop SOP: [`docs/ops/project-1-review-queue-daily-loop.md`](./docs/ops/project-1-review-queue-daily-loop.md)
 
 Project #1 status sync workflows require **GitHub Projects v2 auth** (separate token).
 Tracking issue: [#80](https://github.com/Clay-Agency/novel-task-tracker/issues/80)

--- a/docs/ops/branch-protection.md
+++ b/docs/ops/branch-protection.md
@@ -2,6 +2,8 @@
 
 Goal: require the **Verify (core)** GitHub Actions check to pass before merging to `main`.
 
+Related Project #1 maintainer docs: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
+
 ## Enable (GitHub UI)
 1. Open the repo on GitHub.
 2. Go to **Settings** → **Branches**.

--- a/docs/ops/ci-maintenance-runbook.md
+++ b/docs/ops/ci-maintenance-runbook.md
@@ -9,6 +9,7 @@ This runbook covers the scheduled CI maintenance workflow used to catch regressi
 ## Related runbooks
 - Project #1 maintainer doc hub: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
 - Projects v2 auth (GitHub App) setup + troubleshooting: [`docs/ops/projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
+- Project #1 review-item triage shortcut: [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md)
 
 ## Trigger modes
 The workflow runs in two ways:

--- a/docs/ops/ci-maintenance-runbook.md
+++ b/docs/ops/ci-maintenance-runbook.md
@@ -7,6 +7,7 @@ This runbook covers the scheduled CI maintenance workflow used to catch regressi
 - Workflow name in GitHub Actions: **Scheduled CI Maintenance**
 
 ## Related runbooks
+- Project #1 maintainer doc hub: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
 - Projects v2 auth (GitHub App) setup + troubleshooting: [`docs/ops/projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
 
 ## Trigger modes

--- a/docs/ops/clay-admin-quickstart.md
+++ b/docs/ops/clay-admin-quickstart.md
@@ -5,6 +5,8 @@ This is a **GitHub-first**, low-friction checklist for Clay (org admin) to unblo
 If you need full details (copy/paste commands, troubleshooting, rotation/incident response), use the canonical runbook:
 - **Projects v2 auth runbook**: [`docs/ops/projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
 
+For the broader Project #1 maintainer doc set and navigation, see [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md).
+
 ## Operational guardrails (recommended)
 
 - **Protect `main` (required check gate)**: [`docs/ops/branch-protection.md`](./branch-protection.md)

--- a/docs/ops/project-1-ci-triage-quick-guide.md
+++ b/docs/ops/project-1-ci-triage-quick-guide.md
@@ -1,0 +1,94 @@
+# Project #1 CI triage quick guide (Issue #272)
+
+Use this when clearing **Project #1** review items and you need a fast, repeatable way to read PR checks.
+This guide is intentionally narrow: it tells maintainers which PR checks are **merge blockers** vs **advisory signals** for the common review-item types.
+
+For deeper failure handling and known GitHub Actions flakes, use the canonical runbook:
+- [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md)
+
+## 1) First sort the PR into one of two buckets
+
+### Docs / process PR
+Use this bucket when the PR mainly changes:
+- `README.md`
+- `docs/**`
+- issue / PR templates
+- project-process text with no app/runtime behavior change
+
+### Automation / code PR
+Use this bucket when the PR changes:
+- `src/**`
+- test code or Playwright/Vitest config
+- `package.json` / `package-lock.json`
+- `.github/workflows/**`
+- build, lint, or TypeScript config
+
+If a PR touches both docs and automation/code surfaces, treat it as **automation / code**.
+
+## 2) Check matrix: required vs advisory
+
+| Check | What it covers | Docs / process PR | Automation / code PR |
+| --- | --- | --- | --- |
+| **Verify (core) / npm run verify:core** | Workflow syntax, lint, typecheck, unit tests, build | **Required** | **Required** |
+| **Markdown link check / check-markdown-links** | Internal link validity in `README.md` and `docs/**` | **Required** when the PR changes docs/README links or file paths; otherwise advisory | **Advisory** unless the PR also changes docs/README links |
+| **CI / test-and-lint** | Lint, typecheck, unit tests, Playwright smoke | **Advisory** for docs/process-only work | **Required** |
+| **Scheduled CI Maintenance** | Weekly maintenance workflow on `main` / manual dispatch | Not a PR merge gate | Not a PR merge gate |
+
+## 3) Fast interpretation rules
+
+### Safe-to-merge pattern: docs / process PR
+Normally safe to merge when:
+1. **Verify (core)** is green.
+2. **Markdown link check** is green if the PR changed docs links, filenames, or relative references.
+3. **CI** is either green or clearly irrelevant to the docs-only diff.
+
+Stop and escalate instead of guessing when a docs/process PR unexpectedly changes dependency-sensitive or automation-sensitive files.
+
+### Safe-to-merge pattern: automation / code PR
+Normally safe to merge when:
+1. **Verify (core)** is green.
+2. **CI** is green.
+3. Any additional check failures are understood and non-blocking.
+
+Treat red **CI** on automation/code PRs as a real merge blocker unless you can prove it is a transient GitHub Actions problem.
+
+## 4) Quick failure meanings
+
+- **Verify (core) red**
+  - Treat as a merge blocker for every PR type.
+  - This is the branch-protection baseline documented in [`branch-protection.md`](./branch-protection.md).
+
+- **Markdown link check red**
+  - Usually means a broken relative link, renamed file, or missing docs target.
+  - For docs/process review items, treat it as blocking if the PR touched `README.md` or `docs/**` navigation.
+
+- **CI red on docs/process PR**
+  - First confirm the diff is truly docs/process only.
+  - If yes, treat it as advisory and note the result in review comments if needed.
+  - If no, reclassify the PR as automation/code and require CI green.
+
+- **CI red on automation/code PR**
+  - Treat as blocking.
+  - Use [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md) for build/test/workflow triage.
+
+## 5) Known GitHub Actions UI/API flake
+
+If a PR or `gh pr checks` briefly shows **no checks reported** right after open/push:
+- wait about 15–60 seconds,
+- retry once,
+- confirm runs exist before assuming triggers are broken.
+
+Reference: known flake notes in [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md).
+
+## 6) Review-clearing order hint
+
+When clearing a queue, do the checks in this order:
+1. Confirm the **issue item** is the canonical Project #1 record.
+2. Confirm the PR is not stacked behind an unmerged prerequisite.
+3. Classify the PR as **docs/process** or **automation/code**.
+4. Read only the checks that matter for that bucket.
+5. Merge only after the required checks for that bucket are green.
+
+Related queue-clearing work in progress:
+- Issue #270 — Project #1 review-clearing quick-start: https://github.com/Clay-Agency/novel-task-tracker/issues/270
+- Issue #266 — merge-order checklist follow-up: https://github.com/Clay-Agency/novel-task-tracker/issues/266

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -20,6 +20,8 @@ Conventions:
 - **Review**: implementation is done and waiting on review/merge (typically there is an open PR).
 - **Done**: work is complete (merged/closed) and no further action is expected.
 
+Maintainer blocker-vs-ready triage guide: [`docs/ops/project-1-triage-guide.md`](./project-1-triage-guide.md)
+
 ## Priority (single select)
 
 Allowed values:

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -18,7 +18,7 @@ Conventions:
 - **Todo**: work not started / no one actively driving it yet.
 - **In progress**: an agent is actively working (usually set `Owner agent`).
 - **Blocked**: cannot proceed due to an external dependency (access, upstream change, waiting on review, etc.). If the blocker is a **decision**, set `Needs decision=True` and state the decision request in the issue.
-- **Review**: implementation is done and waiting on review/merge (typically there is an open PR).
+- **Review**: implementation is done and waiting on review/merge (typically there is an open PR). Draft/stacked PRs do **not** belong here until the next action is truly final review/merge.
 - **Done**: work is complete (merged/closed) and no further action is expected.
 
 Maintainer blocker-vs-ready triage guide: [`docs/ops/project-1-triage-guide.md`](./project-1-triage-guide.md)
@@ -70,5 +70,8 @@ Conventions:
   - `CI: <url>`
   - `Decision record: docs/decisions/DR-XXXX-...md`
   - `QA evidence: <url or docs/qa/...#anchor>`
-- When moving work to **Review** or **Done**, make sure the Evidence field includes the relevant PR/merge reference.
+- For draft/stacked review items, make the state explicit instead of using a plain `PR:` line:
+  - `Draft PR: <url>`
+  - `Blocked by: <url>` or `Ready after: <condition>`
+- When moving work to **Review** or **Done**, make sure the Evidence field includes the relevant PR/merge reference. Switch `Draft PR:` back to `PR:` once the item is actually ready for final review/merge.
 - After merge, run the short post-merge cleanup pass before leaving the item in **Done**: remove redundant PR items, confirm final status, and keep only the durable completion links.

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -3,6 +3,7 @@
 As observed **2026-03-06** (fields/options may evolve).
 
 Project #1 maintainer navigation hub: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
+Project #1 lifecycle map: [`project-1-maintainer-lifecycle-map.md`](./project-1-maintainer-lifecycle-map.md)
 
 ## Status (single select)
 
@@ -21,6 +22,7 @@ Conventions:
 - **Done**: work is complete (merged/closed) and no further action is expected.
 
 Maintainer blocker-vs-ready triage guide: [`docs/ops/project-1-triage-guide.md`](./project-1-triage-guide.md)
+Post-merge cleanup checklist: [`docs/ops/project-1-post-merge-hygiene-checklist.md`](./project-1-post-merge-hygiene-checklist.md)
 
 ## Priority (single select)
 
@@ -69,3 +71,4 @@ Conventions:
   - `Decision record: docs/decisions/DR-XXXX-...md`
   - `QA evidence: <url or docs/qa/...#anchor>`
 - When moving work to **Review** or **Done**, make sure the Evidence field includes the relevant PR/merge reference.
+- After merge, run the short post-merge cleanup pass before leaving the item in **Done**: remove redundant PR items, confirm final status, and keep only the durable completion links.

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -2,6 +2,8 @@
 
 As observed **2026-03-06** (fields/options may evolve).
 
+Project #1 maintainer navigation hub: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
+
 ## Status (single select)
 
 Allowed values:

--- a/docs/ops/project-1-maintainer-lifecycle-map.md
+++ b/docs/ops/project-1-maintainer-lifecycle-map.md
@@ -1,0 +1,87 @@
+# Project #1 maintainer lifecycle map (Issue #284)
+
+Use this as the **compact navigation layer** for Project #1 maintainer work.
+It tells you **which maintainer action comes next** as an item moves from triage → review → merge → post-merge hygiene.
+
+This page does **not** replace the detailed guides.
+Open the linked runbook for the phase you are currently in.
+
+## Lifecycle at a glance
+
+| Phase | Ask this first | Primary maintainer action | Open this guide next |
+| --- | --- | --- | --- |
+| **1. Triage** | What is the real next action for this item? | Set the Project item to `In progress`, `Blocked`, or `Review` based on the current state. | [`project-1-triage-guide.md`](./project-1-triage-guide.md) |
+| **2. Review preparation** | Is this review item correctly represented on Project #1? | Start from the canonical issue item, confirm `Evidence`, and do a fast dependency/risk scan before merge review. | [`project-1-review-clearing-quick-start.md`](./project-1-review-clearing-quick-start.md) |
+| **3. Review queue / merge decision** | Is this PR actually merge-ready, and are the right checks green? | Confirm dependency order, classify the PR, read only the checks that matter, then merge in the right order. | [`project-1-review-queue-daily-loop.md`](./project-1-review-queue-daily-loop.md) and [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md) |
+| **4. Post-merge hygiene** | Did Project #1 end in the correct final state? | Confirm the canonical item, move status to the real end state, update `Evidence`, and remove redundant PR items. | [`project-1-post-merge-hygiene-checklist.md`](./project-1-post-merge-hygiene-checklist.md) |
+| **Any phase: automation anomaly** | Did expected Project automation fail or look wrong? | Check expected automation behavior first, then auth/config only if needed. | [`project-status-sync.md`](./project-status-sync.md) → [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md) |
+
+## Default maintainer path
+
+Use this order for a normal Project #1 maintainer pass:
+
+1. **Triage the item correctly**
+   - Use [`project-1-triage-guide.md`](./project-1-triage-guide.md).
+   - Decide whether the next real action is more implementation, dependency resolution, a Clay decision, or review/merge.
+2. **Start review work from the canonical issue item**
+   - Use [`project-1-review-clearing-quick-start.md`](./project-1-review-clearing-quick-start.md).
+   - Confirm `Status`, `Needs decision`, `Owner agent`, and `Evidence` before treating the PR as mergeable.
+3. **Clear the review queue safely**
+   - Use [`project-1-review-queue-daily-loop.md`](./project-1-review-queue-daily-loop.md).
+   - Use [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md) to decide which checks are merge-blocking for the PR type.
+4. **Run the final post-merge consistency pass**
+   - Use [`project-1-post-merge-hygiene-checklist.md`](./project-1-post-merge-hygiene-checklist.md).
+   - Leave the Project item in its true final state instead of leaving stale review metadata behind.
+
+## Which doc to open by symptom
+
+| If you see... | Open... | Why |
+| --- | --- | --- |
+| An item looks active, but you cannot tell whether it should be `Blocked`, `In progress`, or `Review` | [`project-1-triage-guide.md`](./project-1-triage-guide.md) | Decides blocker-vs-ready status and `Needs decision` usage. |
+| A Project item is in `Review` and you want the shortest safe merge-prep checklist | [`project-1-review-clearing-quick-start.md`](./project-1-review-clearing-quick-start.md) | Gives the compact pre-merge maintainer path. |
+| You are doing a full queue-clearing pass across multiple review items | [`project-1-review-queue-daily-loop.md`](./project-1-review-queue-daily-loop.md) | Provides the end-to-end session SOP. |
+| PR checks are noisy and you only want to know what is actually merge-blocking | [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md) | Separates required vs advisory checks by PR type. |
+| The PR merged, but the board still looks wrong or messy | [`project-1-post-merge-hygiene-checklist.md`](./project-1-post-merge-hygiene-checklist.md) | Handles final status/evidence cleanup and duplicate-item removal. |
+| Project fields did not update after close/merge | [`project-status-sync.md`](./project-status-sync.md) | Explains expected automation behavior and normal no-op cases. |
+| Project automation cannot read/write Project #1 | [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md) | Covers GitHub App/PAT auth and troubleshooting. |
+
+## Minimal phase rules
+
+### 1) Triage
+- `Review` means implementation is complete and the next action is review/merge.
+- `Blocked` means progress is stopped by a dependency; set `Needs decision=True` only for an actual Clay decision blocker.
+- `In progress` means more execution work is still required before review.
+
+Reference: [`project-1-triage-guide.md`](./project-1-triage-guide.md)
+
+### 2) Review
+- Start from the **issue item** as the canonical Project #1 record when it already tracks the PR.
+- Confirm `Evidence` contains the active PR (and CI link when useful).
+- Do not treat green checks as enough until dependency order is clear.
+
+References:
+- [`project-1-review-clearing-quick-start.md`](./project-1-review-clearing-quick-start.md)
+- [`project-1-review-queue-daily-loop.md`](./project-1-review-queue-daily-loop.md)
+- [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md)
+
+### 3) Merge
+- Merge only after the required checks for that PR type are green.
+- Merge prerequisite/base PRs before dependent follow-ups.
+- If dependency order is unclear, pause instead of improvising.
+
+References:
+- [`project-1-review-queue-daily-loop.md`](./project-1-review-queue-daily-loop.md)
+- [`branch-protection.md`](./branch-protection.md)
+
+### 4) Post-merge hygiene
+- Do not leave the canonical item in `Review` after the merge is done.
+- Keep the final `Evidence` durable and short.
+- Remove redundant PR items when the issue item already captures the completed work.
+
+Reference: [`project-1-post-merge-hygiene-checklist.md`](./project-1-post-merge-hygiene-checklist.md)
+
+## Related navigation docs
+
+- Broader maintainer doc hub: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
+- Field semantics: [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+- Project automation behavior: [`project-status-sync.md`](./project-status-sync.md)

--- a/docs/ops/project-1-maintainer-runbook-index.md
+++ b/docs/ops/project-1-maintainer-runbook-index.md
@@ -1,0 +1,50 @@
+# Project #1 maintainer runbook index (Issue #276)
+
+Use this page as the navigation hub for **Clay-Agency org Project #1** maintainer operations.
+It does not replace the detailed runbooks; it points maintainers to the right doc for the task at hand.
+
+## Current maintainer runbook set
+
+### Core Project semantics
+- [`project-1-field-conventions.md`](./project-1-field-conventions.md) — canonical meaning for Project #1 fields, status values, owner expectations, and Evidence usage.
+
+### Project automation and post-merge state
+- [`project-status-sync.md`](./project-status-sync.md) — what the status-sync workflow updates and when it runs.
+- [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md) — GitHub App setup, validation, and troubleshooting when Project automation cannot read/write Project #1.
+- [`projects-v2-auth.md`](./projects-v2-auth.md) — compact auth/setup reference.
+- [`clay-admin-quickstart.md`](./clay-admin-quickstart.md) — fast admin checklist for Clay when project automation needs to be enabled or repaired.
+
+### Merge / review guardrails
+- [`branch-protection.md`](./branch-protection.md) — required PR check and approval baseline for merging to `main`.
+- [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md) — deeper CI failure handling, workflow flakes, and ownership/rotation guidance.
+- [`project-1-workflow-auto-add-filter.md`](./project-1-workflow-auto-add-filter.md) — how to keep Project #1 auto-add rules from pulling in automation/meta issues.
+
+## Recommended reading order for common maintainer work
+
+### Verifying Project state and field usage
+1. [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+2. [`project-status-sync.md`](./project-status-sync.md)
+3. [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
+
+### Reviewing whether a merge path is healthy
+1. [`branch-protection.md`](./branch-protection.md)
+2. [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md)
+3. [`project-status-sync.md`](./project-status-sync.md)
+
+### Repairing Project automation/setup
+1. [`clay-admin-quickstart.md`](./clay-admin-quickstart.md)
+2. [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
+3. [`projects-v2-auth.md`](./projects-v2-auth.md)
+
+## Related follow-ups still tracked in issues
+
+Some review-queue-specific maintainer procedures are still tracked as open follow-ups rather than merged standalone docs:
+- Issue #258 — duplicate review-item cleanup
+- Issue #264 — stacked follow-up PR handling
+- Issue #266 — merge-order checklist
+- Issue #268 — maintainer runbook index/orientation follow-up
+- Issue #270 — review-clearing quick-start
+- Issue #272 — CI triage quick guide for review items
+- Issue #274 — review-queue daily-loop SOP
+
+This index intentionally links only to docs that are currently present in the repo so navigation stays accurate.

--- a/docs/ops/project-1-maintainer-runbook-index.md
+++ b/docs/ops/project-1-maintainer-runbook-index.md
@@ -3,7 +3,19 @@
 Use this page as the navigation hub for **Clay-Agency org Project #1** maintainer operations.
 It does not replace the detailed runbooks; it points maintainers to the right doc for the task at hand.
 
+## Start here
+
+- Lifecycle-by-phase navigation: [`project-1-maintainer-lifecycle-map.md`](./project-1-maintainer-lifecycle-map.md)
+- Field semantics and Project conventions: [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+
 ## Current maintainer runbook set
+
+### Phase guides
+- [`project-1-triage-guide.md`](./project-1-triage-guide.md) — decide whether an item belongs in `In progress`, `Blocked`, or `Review`, and whether `Needs decision` should be set.
+- [`project-1-review-clearing-quick-start.md`](./project-1-review-clearing-quick-start.md) — shortest safe maintainer path before merge review.
+- [`project-1-review-queue-daily-loop.md`](./project-1-review-queue-daily-loop.md) — one-pass SOP for clearing multiple Project #1 review items.
+- [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md) — required vs advisory checks for docs/process vs automation/code PRs.
+- [`project-1-post-merge-hygiene-checklist.md`](./project-1-post-merge-hygiene-checklist.md) — final consistency pass after merge/close.
 
 ### Core Project semantics
 - [`project-1-field-conventions.md`](./project-1-field-conventions.md) — canonical meaning for Project #1 fields, status values, owner expectations, and Evidence usage.
@@ -21,30 +33,28 @@ It does not replace the detailed runbooks; it points maintainers to the right do
 
 ## Recommended reading order for common maintainer work
 
-### Verifying Project state and field usage
-1. [`project-1-field-conventions.md`](./project-1-field-conventions.md)
-2. [`project-status-sync.md`](./project-status-sync.md)
-3. [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
+### Triage an item to its real next action
+1. [`project-1-maintainer-lifecycle-map.md`](./project-1-maintainer-lifecycle-map.md)
+2. [`project-1-triage-guide.md`](./project-1-triage-guide.md)
+3. [`project-1-field-conventions.md`](./project-1-field-conventions.md)
 
-### Reviewing whether a merge path is healthy
-1. [`branch-protection.md`](./branch-protection.md)
-2. [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md)
+### Clear one or more review items safely
+1. [`project-1-maintainer-lifecycle-map.md`](./project-1-maintainer-lifecycle-map.md)
+2. [`project-1-review-clearing-quick-start.md`](./project-1-review-clearing-quick-start.md)
+3. [`project-1-review-queue-daily-loop.md`](./project-1-review-queue-daily-loop.md)
+4. [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md)
+5. [`branch-protection.md`](./branch-protection.md)
+
+### Confirm post-merge Project state
+1. [`project-1-maintainer-lifecycle-map.md`](./project-1-maintainer-lifecycle-map.md)
+2. [`project-1-post-merge-hygiene-checklist.md`](./project-1-post-merge-hygiene-checklist.md)
 3. [`project-status-sync.md`](./project-status-sync.md)
+4. [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
 
-### Repairing Project automation/setup
-1. [`clay-admin-quickstart.md`](./clay-admin-quickstart.md)
+### Repair Project automation/setup
+1. [`project-status-sync.md`](./project-status-sync.md)
 2. [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
-3. [`projects-v2-auth.md`](./projects-v2-auth.md)
-
-## Related follow-ups still tracked in issues
-
-Some review-queue-specific maintainer procedures are still tracked as open follow-ups rather than merged standalone docs:
-- Issue #258 — duplicate review-item cleanup
-- Issue #264 — stacked follow-up PR handling
-- Issue #266 — merge-order checklist
-- Issue #268 — maintainer runbook index/orientation follow-up
-- Issue #270 — review-clearing quick-start
-- Issue #272 — CI triage quick guide for review items
-- Issue #274 — review-queue daily-loop SOP
+3. [`clay-admin-quickstart.md`](./clay-admin-quickstart.md)
+4. [`projects-v2-auth.md`](./projects-v2-auth.md)
 
 This index intentionally links only to docs that are currently present in the repo so navigation stays accurate.

--- a/docs/ops/project-1-post-merge-hygiene-checklist.md
+++ b/docs/ops/project-1-post-merge-hygiene-checklist.md
@@ -1,0 +1,56 @@
+# Project #1 post-merge hygiene checklist (Issue #282)
+
+Use this immediately after a Project #1 review item merges or otherwise reaches a done state.
+
+Keep it short: this is the **final consistency pass** after merge, not a second review.
+
+Related docs:
+- [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+- [`project-status-sync.md`](./project-status-sync.md)
+- [`../../CONTRIBUTING.md#project-1-board-fields-owner-agent--needs-decision--evidence`](../../CONTRIBUTING.md#project-1-board-fields-owner-agent--needs-decision--evidence)
+
+## Maintainer checklist
+
+### 1) Confirm the canonical Project item
+- Keep the **issue item** as the canonical Project #1 record when it already tracks the merged PR.
+- If a separate PR item is now redundant, remove the duplicate PR item instead of leaving parallel done/review records.
+
+### 2) Update `Status` to match the real next action
+- Move the canonical item to **Done** when the merge/close completes the tracked scope.
+- Do **not** leave the item in **Review** after merge just because the PR was recently active.
+- If merge uncovered immediate remaining work on the same issue, move the item to the status that reflects the next real action (`In progress` or `Blocked`).
+
+### 3) Verify `Evidence` explains the final state
+- Replace review-only evidence with the most useful durable completion reference.
+- Keep it short; usually 1–3 lines is enough.
+- Preferred lines:
+  - `PR: <merged-pr-url>`
+  - `Issue: <issue-url>`
+  - `Follow-up: <issue-url>` when cleanup revealed a new required item
+
+### 4) Run a duplicate-item sanity check
+- Make sure Project #1 does **not** keep both:
+  - the completed issue item, and
+  - a stale PR item for the same work
+- If follow-up work was split into a new issue, confirm the new issue is the only active Project item that remains for that workstream.
+
+### 5) Decide whether to leave a note or update durable docs
+- Leave a short **issue/PR note** when the cleanup explains a **one-off item-specific action**:
+  - why a status was corrected
+  - why a duplicate Project item was removed
+  - what small follow-up issue was created
+- Update a **durable doc** (runbook/checklist/convention) when the merge exposed a **repeatable rule, policy change, or recurring hygiene gap** that future maintainers should follow.
+
+## Quick decision rule: note vs durable doc
+
+Use a **note** if the information only helps explain this specific item.
+
+Update a **durable doc** if another maintainer is likely to need the same guidance again during a later cleanup/review pass.
+
+## Expected end state
+
+When this checklist is done:
+- the canonical Project item reflects the true final status
+- `Evidence` contains the merged PR or other durable completion link
+- redundant PR items are removed
+- any repeatable lesson is captured in a maintainer-facing doc instead of being lost in one-off comments

--- a/docs/ops/project-1-review-clearing-quick-start.md
+++ b/docs/ops/project-1-review-clearing-quick-start.md
@@ -1,0 +1,62 @@
+# Project #1 review-clearing quick start (Issue #270)
+
+Use this page when you are actively clearing multiple **Project #1** review items and need the shortest safe maintainer path.
+It is intentionally brief: use it as the session checklist, then open the linked runbooks/issues for full detail.
+
+## Recommended order of checks
+
+### 1) Start from the canonical issue item
+- Open **Project #1** and review the **issue item first**.
+- Confirm the item still matches the issue-first convention:
+  - `Status=Review`
+  - `Owner agent` is still accurate (if used)
+  - `Needs decision=False` unless Clay input is required
+  - `Evidence` includes the active PR link
+- Canonical field definitions + expectations: [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+
+### 2) Do a dependency / risk scan before merge
+- Check whether the PR touches dependency-sensitive files or automation surfaces (`package.json`, `package-lock.json`, `.github/workflows/`, `docs/ops/`).
+- Confirm CI is not hiding a dependency-risk problem, especially audit/build/test failures.
+- Use the failure meanings and triage path in [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md).
+
+### 3) Check CI status on the candidate PR
+- Make sure required PR checks are green before merging.
+- If checks appear missing right after a push/open, treat short-lived "no checks reported" as a possible GitHub propagation delay and retry once before escalating.
+- CI expectations and known Actions flakes: [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md)
+
+### 4) Confirm merge order before pressing merge
+- If multiple review items are related, merge the **prerequisite/base item first**.
+- If the queue includes duplicate PR items, stacked follow-up PRs, or unclear dependencies, stop and use the deeper guide instead of guessing.
+- Current detailed references:
+  - Duplicate PR-item cleanup: [PR #261 / Issue #260](https://github.com/Clay-Agency/novel-task-tracker/pull/261)
+  - Stacked follow-up PR handling: [PR #265 / Issue #264](https://github.com/Clay-Agency/novel-task-tracker/pull/265)
+  - Merge-order checklist: [PR #267 / Issue #266](https://github.com/Clay-Agency/novel-task-tracker/pull/267)
+
+### 5) Merge, then verify status/evidence updates
+- After merge, check whether Project automation should update the item automatically.
+- Confirm the issue item still has the right `Evidence` and resulting `Status`.
+- Expected automation behavior: [`project-status-sync.md`](./project-status-sync.md)
+- Field requirements for `Evidence` / `Status`: [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+
+### 6) Escalate only if behavior looks wrong
+- If the merge result is correct but Project fields did not update, use the auth/config troubleshooting runbook.
+- Projects v2 auth + troubleshooting: [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
+
+## Fast stop conditions
+
+Pause the review-clearing session and treat the item as a maintainer anomaly when:
+- `Needs decision=True` or the issue clearly needs a Clay decision
+- the PR is stacked on an unmerged prerequisite
+- duplicate issue/PR items make the canonical record unclear
+- CI is red for a real failure (not a transient checks delay)
+- Project status/evidence automation behaves differently from [`project-status-sync.md`](./project-status-sync.md)
+
+## One-screen maintainer checklist
+
+1. Issue item is the canonical review record.
+2. `Evidence` points at the active PR.
+3. Dependency/automation risk checked.
+4. PR CI green.
+5. Merge order confirmed.
+6. Post-merge `Status`/`Evidence` verified.
+7. Auth/config troubleshooting only if expected automation failed.

--- a/docs/ops/project-1-review-clearing-quick-start.md
+++ b/docs/ops/project-1-review-clearing-quick-start.md
@@ -9,6 +9,7 @@ It is intentionally brief: use it as the session checklist, then open the linked
 - Open **Project #1** and review the **issue item first**.
 - Confirm the item still matches the issue-first convention:
   - `Status=Review`
+  - if the PR is still draft/stacked, stop and move it out of `Review` before continuing
   - `Owner agent` is still accurate (if used)
   - `Needs decision=False` unless Clay input is required
   - `Evidence` includes the active PR link
@@ -26,7 +27,7 @@ It is intentionally brief: use it as the session checklist, then open the linked
 
 ### 4) Confirm merge order before pressing merge
 - If multiple review items are related, merge the **prerequisite/base item first**.
-- If the queue includes duplicate PR items, stacked follow-up PRs, or unclear dependencies, stop and use the deeper guide instead of guessing.
+- If the queue includes duplicate PR items, stacked follow-up PRs, or unclear dependencies, stop and use the deeper guide instead of guessing. Draft/stacked PRs are not merge-ready review items yet.
 - Current detailed references:
   - Duplicate PR-item cleanup: [PR #261 / Issue #260](https://github.com/Clay-Agency/novel-task-tracker/pull/261)
   - Stacked follow-up PR handling: [PR #265 / Issue #264](https://github.com/Clay-Agency/novel-task-tracker/pull/265)

--- a/docs/ops/project-1-review-queue-daily-loop.md
+++ b/docs/ops/project-1-review-queue-daily-loop.md
@@ -1,0 +1,127 @@
+# Project #1 review-queue daily loop SOP (Issue #274)
+
+Use this SOP when doing one focused maintainer pass through **Clay-Agency org Project #1** review items.
+It is intentionally compact: follow this start-to-finish flow, and use the linked runbooks only when you need detail.
+
+## Goal
+
+In one session:
+1. scan the current **Review** queue,
+2. identify mergeable items,
+3. avoid merging PRs out of dependency order,
+4. merge items whose required checks are green,
+5. confirm post-merge Project state is correct.
+
+## Before you start
+
+Have these references open:
+- Project field meanings: [`project-1-field-conventions.md`](./project-1-field-conventions.md)
+- CI interpretation for review items: [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md)
+- Branch protection baseline: [`branch-protection.md`](./branch-protection.md)
+- Project status sync behavior: [`project-status-sync.md`](./project-status-sync.md)
+- Projects v2 auth/troubleshooting: [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md)
+- Deep CI failure handling: [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md)
+
+## Daily loop
+
+### 1) Scan the Review queue
+
+Start with Project #1 items whose **Status** is `Review`.
+For each item, identify the canonical links:
+- issue link
+- open PR link
+- latest CI/check context
+
+If an item is in `Review` but has no open PR, remove it from the merge pass and correct the Project state before continuing.
+
+### 2) Confirm the issue is the canonical Project record
+
+Use the **issue** as the source-of-truth Project item whenever possible.
+Before reviewing the PR, confirm the issue still reflects the work accurately:
+- title/scope still matches the PR,
+- **Owner agent** is still correct,
+- **Needs decision** is not blocking,
+- **Evidence** includes the current PR link when applicable.
+
+Field meanings and expectations live in [`project-1-field-conventions.md`](./project-1-field-conventions.md).
+
+### 3) Check dependency / merge order before reading CI
+
+Do not merge a PR just because checks are green.
+First confirm it is not blocked behind another open PR.
+
+Look for signs of dependency such as:
+- PR body or issue notes referencing a prerequisite PR/issue,
+- stacked branch naming or “based on” language,
+- review comments noting “merge after <other PR>”,
+- failing/irrelevant diffs caused by a missing upstream merge.
+
+If the PR depends on another open PR:
+- leave it in the queue,
+- merge the prerequisite first,
+- then refresh checks/rebase status before returning.
+
+### 4) Classify the PR and read only the checks that matter
+
+Use [`project-1-ci-triage-quick-guide.md`](./project-1-ci-triage-quick-guide.md) to bucket the PR:
+- **docs / process PR**, or
+- **automation / code PR**.
+
+Then apply the required checks for that bucket:
+- **Always require** `Verify (core)`.
+- Require **Markdown link check** when docs/README links or file paths changed.
+- Require full **CI** for automation/code PRs.
+- Treat scheduled maintenance workflows as non-gating.
+
+If a required check is red, stop and triage instead of guessing.
+Use [`ci-maintenance-runbook.md`](./ci-maintenance-runbook.md) when the failure needs deeper handling.
+
+### 5) Merge the ready PRs
+
+A PR is normally ready to merge when:
+- scope still matches the issue,
+- it is not blocked by dependency order,
+- required checks for its bucket are green,
+- there is no open decision preventing merge.
+
+Merge in dependency order, oldest prerequisite first.
+After each merge, refresh the queue before acting on the next item.
+A merge can change which downstream items are now ready.
+
+### 6) Confirm post-merge Project updates
+
+After merge, confirm the Project item moved to the expected end state.
+The status-sync workflow is supposed to reconcile merged work, but maintainers should still verify the result.
+
+Check that:
+- the issue/PR no longer needs active review handling,
+- **Status** moved appropriately toward `Done`,
+- **Evidence** contains the merged PR reference,
+- any stale `Needs decision=True` flag was cleared if no longer applicable.
+
+If the automatic Project update did not happen:
+- review [`project-status-sync.md`](./project-status-sync.md),
+- check Projects auth/troubleshooting in [`projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md),
+- then correct the Project item manually if needed.
+
+## Fast stop conditions
+
+Pause the loop and escalate instead of improvising when:
+- the Project item and PR scope no longer match,
+- a dependency chain is unclear,
+- required checks are failing for unclear reasons,
+- branch protection behavior differs from the runbook,
+- Project automation did not update and the cause is not obvious,
+- a Clay decision is required before merge.
+
+## One-pass maintainer checklist
+
+Use this as the compact session checklist:
+1. Open Project #1 `Review` items.
+2. Verify each item has the right issue + PR pairing.
+3. Check for prerequisite / stacked PR dependencies.
+4. Classify each PR by review bucket.
+5. Read only the required checks for that bucket.
+6. Merge only the items that are truly ready.
+7. Verify post-merge Project/Evidence state.
+8. Escalate unclear blockers instead of guessing.

--- a/docs/ops/project-1-triage-guide.md
+++ b/docs/ops/project-1-triage-guide.md
@@ -1,0 +1,91 @@
+# Project #1 maintainer triage guide — blocker vs ready (Issue #280)
+
+Use this during Project #1 cleanup/review passes when an item looks active but it is not obvious whether it should stay in **Review**, move to **Blocked**, or return to **In progress**.
+
+This guide is intentionally short. Reuse the linked runbooks for the detailed mechanics.
+
+## Fast branching rule
+
+Ask these in order:
+
+1. **Is implementation complete and is the next maintainer action review/merge?**
+   - **Yes** → keep/move item to **Review**.
+2. **Is progress blocked by a Clay decision?**
+   - **Yes** → move item to **Blocked** and set `Needs decision=True`.
+3. **Is progress blocked by some other dependency?**
+   - **Yes** → move item to **Blocked** and keep `Needs decision=False` unless Clay input is explicitly required.
+4. **Otherwise**
+   - keep/move item to **In progress** (work still needed before review).
+
+## Triage outcomes
+
+| Situation | Project `Status` | `Needs decision` | Maintainer action |
+| --- | --- | --- | --- |
+| Implementation complete; waiting on review/merge | `Review` | `False` | Make sure `Evidence` links the active PR/CI and request final review. |
+| Blocked on explicit Clay decision (policy, direction, trade-off) | `Blocked` | `True` | Add/remove the repo `needs-decision` label as needed, state the decision question + options in the issue, and link the decision brief/evidence. |
+| Blocked on external dependency but **not** a Clay decision (access, upstream fix, reviewer identity constraint, waiting on another repo/system) | `Blocked` | `False` | Record the dependency clearly in the issue and `Evidence`, plus the next trigger/checkpoint. |
+| Work is still being implemented or revised before review | `In progress` | `False` (usually) | Leave with current owner and continue execution work. |
+
+## How to classify common Project #1 cases
+
+### 1) Clay-decision blocker
+Use this when the work cannot move until Clay chooses a direction.
+
+Examples:
+- **#80** — auth approach decision for Project #1 automation (**GitHub App vs PAT**)
+- **#126** — priority taxonomy decision (**add P3 vs collapse into P2**)
+
+Maintainer checklist:
+- Set Project `Status` to **Blocked**.
+- Set Project `Needs decision` to **True**.
+- Apply repo label `needs-decision`.
+- Ensure the issue contains:
+  - the decision question,
+  - 1–3 options,
+  - recommended default if helpful,
+  - links to supporting evidence/runbooks.
+- Link the durable doc instead of rewriting the whole context:
+  - [`docs/ops/open-decisions.md`](./open-decisions.md)
+  - [`docs/ops/needs-decision-snapshot.md`](./needs-decision-snapshot.md)
+
+## 2) Dependency blocker (not decision-bound)
+Use this when the work is blocked, but the blocker is an external dependency rather than a Clay decision.
+
+Examples:
+- waiting on upstream access/configuration
+- waiting on another PR/repo/workflow
+- waiting on a reviewer identity or permissions constraint to be resolved
+
+Maintainer checklist:
+- Set Project `Status` to **Blocked**.
+- Keep Project `Needs decision` as **False** unless there is an actual Clay decision request.
+- Do **not** apply `needs-decision` just because the item is stalled.
+- In the issue, write the blocker in one sentence and state what event unblocks it.
+- Put the concrete evidence link in the Project `Evidence` field.
+
+## 3) Merge-ready review item
+Use this when implementation is done and the next meaningful step is review/merge rather than more execution.
+
+Maintainer checklist:
+- Set Project `Status` to **Review**.
+- Keep Project `Needs decision` at **False**.
+- Ensure Project `Evidence` includes, at minimum:
+  - `PR: <url>`
+  - `CI: <url>` when relevant
+- Follow the review flow in [`CONTRIBUTING.md`](../../CONTRIBUTING.md#2-stage-review-process-required).
+- Apply the de-duplication rule from [`docs/ops/project-1-field-conventions.md`](./project-1-field-conventions.md): keep the **issue item** as canonical when it already tracks the active PR.
+
+## Short maintainer checklist for cleanup passes
+
+When triaging a Project #1 item, confirm:
+- Is the next action **review/merge**, **decision**, **dependency resolution**, or **more implementation**?
+- Does `Status` match that next action?
+- Does `Needs decision` reflect an actual Clay decision blocker, not just general delay?
+- Does `Evidence` contain the single most useful link for the current state?
+- If the item is in **Review**, is there a redundant PR item that should be removed?
+
+## Related docs
+
+- Field definitions and evidence conventions: [`docs/ops/project-1-field-conventions.md`](./project-1-field-conventions.md)
+- Needs-decision process: [`CONTRIBUTING.md#needs-decision-convention`](../../CONTRIBUTING.md#needs-decision-convention)
+- Open decision checklist: [`docs/ops/open-decisions.md`](./open-decisions.md)

--- a/docs/ops/project-1-triage-guide.md
+++ b/docs/ops/project-1-triage-guide.md
@@ -10,10 +10,11 @@ Ask these in order:
 
 1. **Is implementation complete and is the next maintainer action review/merge?**
    - **Yes** → keep/move item to **Review**.
+   - **No, the PR is still draft or intentionally stacked behind another open PR** → do **not** treat it as `Review` yet. Continue below.
 2. **Is progress blocked by a Clay decision?**
    - **Yes** → move item to **Blocked** and set `Needs decision=True`.
 3. **Is progress blocked by some other dependency?**
-   - **Yes** → move item to **Blocked** and keep `Needs decision=False` unless Clay input is explicitly required.
+   - **Yes** → move item to **Blocked** and keep `Needs decision=False` unless Clay input is explicitly required. This includes green-but-draft PRs that are waiting on a prerequisite merge/rebase before final review.
 4. **Otherwise**
    - keep/move item to **In progress** (work still needed before review).
 
@@ -22,9 +23,10 @@ Ask these in order:
 | Situation | Project `Status` | `Needs decision` | Maintainer action |
 | --- | --- | --- | --- |
 | Implementation complete; waiting on review/merge | `Review` | `False` | Make sure `Evidence` links the active PR/CI and request final review. |
+| Draft PR waiting on another PR / stack dependency before final review | `Blocked` | `False` | Keep it out of the active `Review` queue. In `Evidence`, use `Draft PR: <url>` and `Blocked by: <url>` (or `Ready after: <condition>`). |
 | Blocked on explicit Clay decision (policy, direction, trade-off) | `Blocked` | `True` | Add/remove the repo `needs-decision` label as needed, state the decision question + options in the issue, and link the decision brief/evidence. |
 | Blocked on external dependency but **not** a Clay decision (access, upstream fix, reviewer identity constraint, waiting on another repo/system) | `Blocked` | `False` | Record the dependency clearly in the issue and `Evidence`, plus the next trigger/checkpoint. |
-| Work is still being implemented or revised before review | `In progress` | `False` (usually) | Leave with current owner and continue execution work. |
+| Work is still being implemented or revised before review | `In progress` | `False` (usually) | Leave with current owner and continue execution work. Draft PRs that are still changing belong here if they are not dependency-blocked. |
 
 ## How to classify common Project #1 cases
 
@@ -63,7 +65,19 @@ Maintainer checklist:
 - In the issue, write the blocker in one sentence and state what event unblocks it.
 - Put the concrete evidence link in the Project `Evidence` field.
 
-## 3) Merge-ready review item
+## 3) Draft or stacked PR that is not review-ready yet
+Use this when a PR exists, but it is still **draft** or intentionally stacked behind another open PR, so the next maintainer action is **not** final review/merge yet.
+
+Maintainer checklist:
+- If the PR is waiting on a prerequisite merge/rebase, set Project `Status` to **Blocked**.
+- Keep Project `Needs decision` at **False** unless the stack order itself needs a Clay decision.
+- Keep the **issue item** as the canonical Project record when it already tracks the draft PR.
+- In Project `Evidence`, make the state obvious at a glance:
+  - `Draft PR: <url>`
+  - `Blocked by: <url>` or `Ready after: <condition>`
+- Move the item to **Review** only when the PR is ready for final review/merge (for example, draft removed and prerequisite merged).
+
+## 4) Merge-ready review item
 Use this when implementation is done and the next meaningful step is review/merge rather than more execution.
 
 Maintainer checklist:

--- a/docs/ops/project-1-workflow-auto-add-filter.md
+++ b/docs/ops/project-1-workflow-auto-add-filter.md
@@ -2,6 +2,8 @@
 
 Use this when Project #1 is auto-adding “meta”/automation issues (for context, see #169).
 
+Related Project #1 maintainer docs: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
+
 ## Goal
 Update the Project #1 **Workflows → Auto-add** filter to exclude issues labeled `automation` by appending `-label:automation`.
 

--- a/docs/ops/project-status-sync.md
+++ b/docs/ops/project-status-sync.md
@@ -12,6 +12,8 @@ It syncs **Clay-Agency org Project #1** (Projects v2 / `ProjectV2`) fields when:
 
 Detailed setup (GitHub App least-privilege, PAT fallback, troubleshooting): [`docs/ops/projects-v2-auth-runbook.md`](./projects-v2-auth-runbook.md).
 
+For the broader Project #1 maintainer runbook set, start from [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md).
+
 GitHub’s built-in Actions token (`secrets.GITHUB_TOKEN`) **cannot** update **organization Projects v2** via GraphQL.
 
 You must provide **one** of the following:

--- a/docs/ops/projects-v2-auth-runbook.md
+++ b/docs/ops/projects-v2-auth-runbook.md
@@ -1,5 +1,7 @@
 # Runbook — Projects v2 auth (GitHub App) for Clay-Agency org Project #1
 
+Related maintainer docs: [`project-1-maintainer-runbook-index.md`](./project-1-maintainer-runbook-index.md)
+
 This repo has GitHub Actions automation that **reads + updates** the Clay-Agency **organization Project (Projects v2 / `ProjectV2`)** via the **GraphQL API**.
 
 GitHub’s built-in Actions token (`GITHUB_TOKEN`) **cannot** mutate **organization Projects v2**, so we use a **GitHub App installation token** minted at runtime.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest",
     "e2e": "playwright test",
     "check:workflows": "ruby -e 'require \"yaml\"; Dir[\".github/workflows/*.{yml,yaml}\"].sort.each { |f| YAML.load_file(f); puts \"OK #{f}\" }'",
-    "docs:links": "lychee --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
+    "docs:links": "node scripts/docs-links.mjs",
     "docs:links:docker": "docker run --rm -v \"$PWD\":/workdir -w /workdir ghcr.io/lycheeverse/lychee:latest --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
     "verify:quick": "npm run check:workflows && npm run lint && npm run typecheck && npm test",
     "verify:core": "npm run verify:quick && npm run build"

--- a/scripts/docs-links.mjs
+++ b/scripts/docs-links.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+const targets = ['README.md', 'docs'];
+const lycheeArgs = [
+  '--no-progress',
+  '--offline',
+  '--exclude',
+  '^https?://',
+  '--exclude',
+  '^mailto:',
+  ...targets,
+];
+const dockerArgs = [
+  'run',
+  '--rm',
+  '-v',
+  `${process.cwd()}:/workdir`,
+  '-w',
+  '/workdir',
+  'ghcr.io/lycheeverse/lychee:latest',
+  ...lycheeArgs,
+];
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+    env: process.env,
+    ...options,
+  });
+}
+
+function hasCommand(command) {
+  const probe = spawnSync('sh', ['-lc', `command -v ${command}`], {
+    cwd: process.cwd(),
+    stdio: 'ignore',
+    env: process.env,
+  });
+  return probe.status === 0;
+}
+
+if (hasCommand('lychee')) {
+  const result = run('lychee', lycheeArgs);
+  process.exit(result.status ?? 1);
+}
+
+if (hasCommand('docker')) {
+  const dockerInfo = spawnSync('docker', ['info'], {
+    cwd: process.cwd(),
+    stdio: 'ignore',
+    env: process.env,
+  });
+
+  if (dockerInfo.status === 0) {
+    const result = run('docker', dockerArgs);
+    process.exit(result.status ?? 1);
+  }
+}
+
+console.error('docs:links could not find a runnable link checker.');
+console.error('');
+console.error('Choose one of these fixes, then rerun `npm run docs:links`:');
+console.error('1. Install lychee locally:');
+console.error('   brew install lychee');
+console.error('   # or: cargo install lychee');
+console.error('2. Start Docker/OrbStack so the Docker fallback can run.');
+console.error('');
+console.error('If you want the Docker-only path after Docker is ready, run:');
+console.error('  npm run docs:links:docker');
+process.exit(1);


### PR DESCRIPTION
## Summary
- add a Project #1 maintainer lifecycle map covering triage -> review -> merge -> post-merge hygiene
- cross-link the map from the maintainer runbook index, field conventions, README, and CONTRIBUTING
- include the recent phase-specific maintainer guides referenced by issue #284 so the lifecycle map points to repo-local runbooks instead of dead/stale placeholders

## Why
Issue #284 asks for a single compact navigation layer over the growing Project #1 maintainer runbook set. This PR adds that navigation layer and wires it into the maintainer entry points.

## Validation
- targeted Python validation for the edited maintainer docs / README / CONTRIBUTING confirmed:
  - no merge-conflict markers
  - all relative Markdown links in touched files resolve
- repo `npm run docs:links` command could not be completed locally because `lychee` is not installed on this machine (`sh: lychee: command not found`)

Closes #284
