### PR TITLE
chore: improve local doctor preflight reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,14 @@ nvm use
 
 (`.nvmrc` is set to `20`.)
 
+Before deeper verification, you can run a quick local preflight:
+
+```bash
+npm run doctor:local
+```
+
+This catches common setup mismatches early (repo root, `.nvmrc`, `npm`, lockfile, and install state).
+
 ## Branch + PR flow
 
 1. Branch from `main` with `feat/issue-<number>-<summary>`.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install
 ```
 
 Use `npm run doctor:local` as a lightweight preflight for local setup assumptions before spending time on lint/test/build failures.
-It checks the repo root, `.nvmrc`, `npm` availability, lockfile presence, and whether dependencies are already installed.
+It checks the repo root, `.nvmrc`, the repo's expected Node major, current runtime details, `npm` availability, lockfile presence, and whether dependencies are already installed.
 
 ## Run locally
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,8 +30,13 @@ Checklist: [`docs/ops/open-decisions.md`](./docs/ops/open-decisions.md)
 
 ## Setup
 ```bash
+nvm use
+npm run doctor:local
 npm install
 ```
+
+Use `npm run doctor:local` as a lightweight preflight for local setup assumptions before spending time on lint/test/build failures.
+It checks the repo root, `.nvmrc`, `npm` availability, lockfile presence, and whether dependencies are already installed.
 
 ## Run locally
 ```bash

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "doctor:local": "node scripts/doctor-local.mjs",
     "dev": "vite",
     "start": "vite",
     "build": "vite build",

--- a/scripts/doctor-local.mjs
+++ b/scripts/doctor-local.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { spawnSync } from 'node:child_process';
+
+const cwd = process.cwd();
+const packageJsonPath = path.join(cwd, 'package.json');
+const packageLockPath = path.join(cwd, 'package-lock.json');
+const nodeModulesPath = path.join(cwd, 'node_modules');
+const nvmrcPath = path.join(cwd, '.nvmrc');
+
+const checks = [];
+
+function addCheck(ok, label, detail, nextStep) {
+  checks.push({ ok, label, detail, nextStep });
+}
+
+if (!existsSync(packageJsonPath)) {
+  console.error('✖ package.json not found. Run this command from the repository root.');
+  process.exit(1);
+}
+
+const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const nvmrcExists = existsSync(nvmrcPath);
+const nvmrcVersion = nvmrcExists ? readFileSync(nvmrcPath, 'utf8').trim() : null;
+const npmProbe = spawnSync('npm', ['--version'], { cwd, stdio: 'pipe' });
+const npmAvailable = npmProbe.status === 0;
+const npmVersion = npmAvailable ? npmProbe.stdout.toString().trim() : null;
+
+addCheck(true, 'Repository root', `package.json found at ${packageJsonPath}`);
+addCheck(nvmrcExists, 'Node version file', nvmrcExists ? `.nvmrc present (${nvmrcVersion})` : '.nvmrc missing', 'Add `.nvmrc` so local Node selection stays aligned with CI.');
+addCheck(existsSync(packageLockPath), 'Lockfile', existsSync(packageLockPath) ? 'package-lock.json present' : 'package-lock.json missing', 'Restore `package-lock.json` before install/verify commands.');
+addCheck(npmAvailable, 'npm available', npmAvailable ? `npm ${npmVersion}` : 'npm command not found', 'Install Node.js/npm or reactivate your shell environment before local verify commands.');
+addCheck(existsSync(nodeModulesPath), 'Dependencies installed', existsSync(nodeModulesPath) ? 'node_modules directory present' : 'node_modules directory missing', 'Run `npm install` before lint/test/build commands.');
+addCheck(true, 'Node.js runtime', process.version);
+addCheck(true, 'Package name', pkg.name ?? '(missing)');
+
+const failures = checks.filter((check) => !check.ok);
+
+for (const check of checks) {
+  const icon = check.ok ? '✔' : '✖';
+  console.log(`${icon} ${check.label}: ${check.detail}`);
+  if (!check.ok && check.nextStep) {
+    console.log(`  → ${check.nextStep}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.log(`\nDoctor result: ${failures.length} issue(s) detected.`);
+  process.exit(1);
+}
+
+console.log('\nDoctor result: OK');

--- a/scripts/doctor-local.mjs
+++ b/scripts/doctor-local.mjs
@@ -24,6 +24,8 @@ if (!existsSync(packageJsonPath)) {
 const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 const nvmrcExists = existsSync(nvmrcPath);
 const nvmrcVersion = nvmrcExists ? readFileSync(nvmrcPath, 'utf8').trim() : null;
+const expectedNodeMajor = nvmrcVersion ? Number.parseInt(nvmrcVersion, 10) : null;
+const currentNodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10);
 const npmProbe = spawnSync('npm', ['--version'], { cwd, stdio: 'pipe' });
 const npmAvailable = npmProbe.status === 0;
 const npmVersion = npmAvailable ? npmProbe.stdout.toString().trim() : null;
@@ -33,7 +35,8 @@ addCheck(nvmrcExists, 'Node version file', nvmrcExists ? `.nvmrc present (${nvmr
 addCheck(existsSync(packageLockPath), 'Lockfile', existsSync(packageLockPath) ? 'package-lock.json present' : 'package-lock.json missing', 'Restore `package-lock.json` before install/verify commands.');
 addCheck(npmAvailable, 'npm available', npmAvailable ? `npm ${npmVersion}` : 'npm command not found', 'Install Node.js/npm or reactivate your shell environment before local verify commands.');
 addCheck(existsSync(nodeModulesPath), 'Dependencies installed', existsSync(nodeModulesPath) ? 'node_modules directory present' : 'node_modules directory missing', 'Run `npm install` before lint/test/build commands.');
-addCheck(true, 'Node.js runtime', process.version);
+addCheck(true, 'Expected Node major', expectedNodeMajor ? String(expectedNodeMajor) : 'unknown');
+addCheck(true, 'Node.js runtime', `${process.version} (major ${currentNodeMajor})`);
 addCheck(true, 'Package name', pkg.name ?? '(missing)');
 
 const failures = checks.filter((check) => !check.ok);


### PR DESCRIPTION
## Summary
- add `scripts/doctor-local.mjs` as a lightweight local preflight
- expose the preflight as `npm run doctor:local`
- report the repo's expected Node major from `.nvmrc` alongside the current runtime major
- document the preflight/runtime signal in `README.md` and `CONTRIBUTING.md`

Closes #288
Closes #290

## Validation
- `npm run doctor:local`
- `npm run verify:quick`

## Stage 1 self-review
- Requirement coverage complete for the local doctor preflight and Node-version reporting follow-up
- Scope is limited to local tooling/docs; no app runtime behavior changed
- The runtime/version output is advisory and helps spot drift before deeper verification

## Risks / edge cases
- The preflight reports version drift but does not fail when the active Node version differs from `.nvmrc`
- `Dependencies installed` is currently a directory-presence check (`node_modules`), not a full dependency integrity validation
