### PR TITLE
chore: improve docs link check fallback UX

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,25 +65,19 @@ CI validates **internal/relative** links in `README.md` and `docs/**` (external 
 Run locally:
 
 ```bash
-# Option A: run via npm (requires lychee installed)
-#   brew install lychee
-#   # or: cargo install lychee
-
+# Preferred: auto-detect a runnable checker.
+# - Uses local lychee when installed.
+# - Falls back to Docker when the daemon is reachable.
+# - Prints exact setup steps if neither path is available.
 npm run docs:links
 
-# Option B: Docker (no local lychee install required)
-#   Optional readiness check (daemon reachable):
-#   docker info >/dev/null
-
+# Force the Docker path (useful after starting Docker/OrbStack)
+# docker info >/dev/null
 npm run docs:links:docker
 
-# (Equivalent direct command)
-# docker run --rm -v "$(pwd)":/workdir -w /workdir \
-#   ghcr.io/lycheeverse/lychee:latest \
-#   --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs
-
-# If you see "Cannot connect to the Docker daemon", start Docker/OrbStack first,
-# then rerun the command.
+# Optional: install lychee for the local path
+# brew install lychee
+# # or: cargo install lychee
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ npm run lint
 npm run typecheck
 npm run test
 npm run e2e
+npm run docs:links
+npm run verify:quick
+npm run verify:core
 ```
 
 ## Build

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest",
     "e2e": "playwright test",
     "check:workflows": "ruby -e 'require \"yaml\"; Dir[\".github/workflows/*.{yml,yaml}\"].sort.each { |f| YAML.load_file(f); puts \"OK #{f}\" }'",
-    "docs:links": "lychee --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
+    "docs:links": "node scripts/docs-links.mjs",
     "docs:links:docker": "docker run --rm -v \"$PWD\":/workdir -w /workdir ghcr.io/lycheeverse/lychee:latest --no-progress --offline --exclude '^https?://' --exclude '^mailto:' README.md docs",
     "verify:quick": "npm run check:workflows && npm run lint && npm run typecheck && npm test",
     "verify:core": "npm run verify:quick && npm run build"

--- a/scripts/docs-links.mjs
+++ b/scripts/docs-links.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+const targets = ['README.md', 'docs'];
+const lycheeArgs = [
+  '--no-progress',
+  '--offline',
+  '--exclude',
+  '^https?://',
+  '--exclude',
+  '^mailto:',
+  ...targets,
+];
+const dockerArgs = [
+  'run',
+  '--rm',
+  '-v',
+  `${process.cwd()}:/workdir`,
+  '-w',
+  '/workdir',
+  'ghcr.io/lycheeverse/lychee:latest',
+  ...lycheeArgs,
+];
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+    env: process.env,
+    ...options,
+  });
+}
+
+function hasCommand(command) {
+  const probe = spawnSync('sh', ['-lc', `command -v ${command}`], {
+    cwd: process.cwd(),
+    stdio: 'ignore',
+    env: process.env,
+  });
+  return probe.status === 0;
+}
+
+if (hasCommand('lychee')) {
+  const result = run('lychee', lycheeArgs);
+  process.exit(result.status ?? 1);
+}
+
+if (hasCommand('docker')) {
+  const dockerInfo = spawnSync('docker', ['info'], {
+    cwd: process.cwd(),
+    stdio: 'ignore',
+    env: process.env,
+  });
+
+  if (dockerInfo.status === 0) {
+    const result = run('docker', dockerArgs);
+    process.exit(result.status ?? 1);
+  }
+}
+
+console.error('docs:links could not find a runnable link checker.');
+console.error('');
+console.error('Choose one of these fixes, then rerun `npm run docs:links`:');
+console.error('1. Install lychee locally:');
+console.error('   brew install lychee');
+console.error('   # or: cargo install lychee');
+console.error('2. Start Docker/OrbStack so the Docker fallback can run.');
+console.error('');
+console.error('If you want the Docker-only path after Docker is ready, run:');
+console.error('  npm run docs:links:docker');
+process.exit(1);


### PR DESCRIPTION
## Summary
- add an auto-detecting `docs:links` helper for local docs-link verification
- prefer local `lychee` when installed, otherwise fall back to Docker when available
- print exact remediation steps when neither path is available
- update `README.md` and `CONTRIBUTING.md` so the local docs-link verification path is clearer

Closes #287

## Validation
- `npm run verify:quick`
- `npm run docs:links` (expected actionable guidance when `lychee` is missing and Docker is unavailable)

## Stage 1 self-review
- scope is limited to local tooling/docs; no runtime app behavior changed
- fallback UX now points contributors at concrete next steps instead of a dead end
- `docs:links` remains compatible with both local-tool and Docker-based workflows

## Risks / edge cases
- fallback behavior depends on local environment detection and intentionally does not force-install tools
- the no-checker path still exits non-zero after printing remediation guidance