### PR TITLE
docs: add combined verification commands to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ When you add an issue/PR to the **Clay-Agency org Project #1** board, keep these
 
 - **Owner agent**: the agent accountable for the next step. Set when work starts; clear if unowned.
 - **Needs decision**: set `True` (and apply label `needs-decision`) only when progress is blocked on an explicit Clay decision. Put the decision question + options in the issue.
-- **Evidence**: paste the key links that justify the current state (PR, CI run, screenshots/GIFs, decision record). Keep it short; one item per line.
+- **Evidence**: paste the key links that justify the current state (PR, CI run, screenshots/GIFs, decision record). Keep it short; one item per line. For draft stacked PRs, make that explicit with lines like `PR (draft): ...`, `Depends on: ...`, and `Ready after: ...`.
 
 Details: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
 
@@ -57,6 +57,7 @@ For QA findings (and QA-discovered bugs), include a direct link to the relevant 
 
 - [Projects v2 auth runbook](./docs/ops/projects-v2-auth-runbook.md): Use when configuring or debugging GitHub Actions auth for workflows that read/update the Clay-Agency org Project #1 (GraphQL `ProjectV2`).
 - [Project #1 field conventions](./docs/ops/project-1-field-conventions.md): Use when triaging work on the Project #1 board or building automation that writes project fields (Status, Priority, Owner agent, Needs decision, Evidence).
+- [Draft stacked review items](./docs/ops/project-1-draft-stacked-review-items.md): Use when a Project #1 item has a draft/stacked PR that is green but intentionally not ready for the active review queue.
 
 ## Markdown link check
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ npm run build
 ### Quick links
 - Projects v2 auth runbook: [`docs/ops/projects-v2-auth-runbook.md`](./docs/ops/projects-v2-auth-runbook.md)
 - Project #1 field conventions: [`docs/ops/project-1-field-conventions.md`](./docs/ops/project-1-field-conventions.md)
+- Draft stacked review items: [`docs/ops/project-1-draft-stacked-review-items.md`](./docs/ops/project-1-draft-stacked-review-items.md)
 - Clay admin quickstart: [`docs/ops/clay-admin-quickstart.md`](./docs/ops/clay-admin-quickstart.md)
 - Branch protection runbook (require **Verify (core)** on `main`): [`docs/ops/branch-protection.md`](./docs/ops/branch-protection.md)
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ npm run test
 npm run e2e
 ```
 
+Recommended combined gates:
+```bash
+npm run verify:quick  # workflows + lint + typecheck + unit/integration tests
+npm run verify:core   # verify:quick + production build
+```
+
+Documentation-only link validation:
+```bash
+npm run docs:links
+```
+
+If `lychee` is not installed locally, use the containerized fallback:
+```bash
+npm run docs:links:docker
+```
+
 ## Build
 ```bash
 npm run build

--- a/docs/ops/project-1-draft-stacked-review-items.md
+++ b/docs/ops/project-1-draft-stacked-review-items.md
@@ -1,0 +1,58 @@
+# Project #1 — handling draft stacked review items
+
+Use this when a Project #1 item has an open PR that is intentionally **draft**, **dependency-bound**, or part of a **stacked docs series** (for example PR #285).
+
+## Default status convention
+
+For draft stacked PRs, keep the Project #1 item in **In progress** by default.
+
+Why:
+- `Review` should mean a maintainer can take a real review/merge action now.
+- Draft stacked PRs are often green but intentionally **not ready for final review**.
+- Keeping them in `In progress` avoids making the review queue look artificially ready.
+
+Move the item to **Review** only when all of the following are true:
+- the PR is no longer draft
+- any required base/dependency PRs are already merged (or are no longer blockers)
+- the author is explicitly asking for review/merge
+- the Evidence field points to the ready PR + relevant CI proof
+
+Use **Blocked** instead of `In progress` only when the next step truly depends on an external blocker (for example: waiting on a prerequisite PR to merge, waiting on access, or waiting on a Clay decision).
+
+## Evidence text convention
+
+When a PR is draft/stacked, make that obvious in the Project #1 `Evidence` field.
+
+Recommended format (one item per line):
+- `PR (draft): <url>`
+- `Depends on: <url or #issue/pr>`
+- `Ready after: <what must happen next>`
+- `CI: <url>`
+
+Example:
+- `PR (draft): https://github.com/Clay-Agency/novel-task-tracker/pull/285`
+- `Depends on: base=main; kept draft until lifecycle-map wording is reviewed`
+- `Ready after: convert PR to ready-for-review and confirm docs links`
+- `CI: https://github.com/Clay-Agency/novel-task-tracker/actions/runs/...`
+
+## Maintainer triage rule
+
+When triaging Project #1 review items:
+1. If the linked PR is **draft**, do **not** treat it as an active `Review` item yet.
+2. Check the Evidence field for the dependency/ready signal.
+3. Keep the item in `In progress` unless a true blocker justifies `Blocked`.
+4. Move it to `Review` once the PR is ready and the dependency note is cleared.
+
+## Author checklist for stacked draft PRs
+
+Before leaving a stacked draft PR in Project #1:
+- keep the PR in **Draft** until it is genuinely reviewable
+- mirror the draft/stacked state in the issue body or latest progress comment
+- update the Project `Evidence` field with the `PR (draft)` + `Ready after` lines
+- avoid moving the item to `Review` just because CI is green
+
+## Related docs
+
+- [Project #1 field conventions](./project-1-field-conventions.md)
+- [CONTRIBUTING.md — Project #1 board fields](../../CONTRIBUTING.md#project-1-board-fields-owner-agent--needs-decision--evidence)
+- [README — Ops / Automation quick links](../../README.md#ops--automation)

--- a/docs/ops/project-1-field-conventions.md
+++ b/docs/ops/project-1-field-conventions.md
@@ -15,7 +15,7 @@ Conventions:
 - **Todo**: work not started / no one actively driving it yet.
 - **In progress**: an agent is actively working (usually set `Owner agent`).
 - **Blocked**: cannot proceed due to an external dependency (access, upstream change, waiting on review, etc.). If the blocker is a **decision**, set `Needs decision=True` and state the decision request in the issue.
-- **Review**: implementation is done and waiting on review/merge (typically there is an open PR).
+- **Review**: implementation is done and waiting on review/merge (typically there is an open PR). Do **not** use `Review` for draft stacked PRs that are intentionally not ready yet; keep those in `In progress` (or `Blocked` if there is a real external blocker). See [`project-1-draft-stacked-review-items.md`](./project-1-draft-stacked-review-items.md).
 - **Done**: work is complete (merged/closed) and no further action is expected.
 
 ## Priority (single select)
@@ -65,3 +65,4 @@ Conventions:
   - `Decision record: docs/decisions/DR-XXXX-...md`
   - `QA evidence: <url or docs/qa/...#anchor>`
 - When moving work to **Review** or **Done**, make sure the Evidence field includes the relevant PR/merge reference.
+- For draft stacked PRs, prefer explicit labels in Evidence such as `PR (draft): ...`, `Depends on: ...`, and `Ready after: ...` so maintainers can distinguish green-but-not-ready work from true review-ready items.


### PR DESCRIPTION
## Summary
- document `npm run verify:quick` and `npm run verify:core` in the README
- document `npm run docs:links` and the Docker fallback
- make the recommended verification path easier to discover during maintenance work

## Verification
- npm run verify:core

Closes #299