### PR TITLE
fix: guard project sync against empty item reads

### DIFF
--- a/.github/scripts/project-status-sync.cjs
+++ b/.github/scripts/project-status-sync.cjs
@@ -18,6 +18,17 @@ function yyyyMmDd(dateLike) {
   return d.toISOString().slice(0, 10);
 }
 
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseRetryCount(value, fallback) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return fallback;
+  return Math.floor(n);
+}
+
 function mapProjectFields(fieldsNodes) {
   const fields = fieldsNodes || [];
 
@@ -264,14 +275,13 @@ async function syncOneItem({ graphql, core, meta, projectId, itemId, doneDate })
   }
 }
 
-async function reconcileProject({ graphql, core, meta, orgLogin, projectNumber }) {
-  core.info(`Reconciling items in ${orgLogin} Project #${projectNumber} (${meta.projectTitle})`);
-
+async function readProjectItemsPage({ graphql, projectId, after }) {
   const query = `
     query($projectId: ID!, $after: String) {
       node(id: $projectId) {
         ... on ProjectV2 {
           items(first: 50, after: $after) {
+            totalCount
             pageInfo { hasNextPage endCursor }
             nodes {
               id
@@ -297,14 +307,133 @@ async function reconcileProject({ graphql, core, meta, orgLogin, projectNumber }
     }
   `;
 
+  return graphql(query, { projectId, after });
+}
+
+async function getRepoProjectMembershipSample({ graphql, owner, repo, projectNumber }) {
+  if (!owner || !repo) return [];
+
+  const query = `
+    query($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        issues(first: 20, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            number
+            url
+            projectItems(first: 20) {
+              nodes { project { number } }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const res = await graphql(query, { owner, repo });
+  const issues = res?.repository?.issues?.nodes || [];
+  return issues.filter((issue) =>
+    (issue?.projectItems?.nodes || []).some((item) => item?.project?.number === projectNumber)
+  );
+}
+
+async function getFirstProjectItemsPageWithRetry({
+  graphql,
+  core,
+  meta,
+  orgLogin,
+  projectNumber,
+  repositoryOwner,
+  repositoryName,
+  maxRetries = 2,
+  retryDelayMs = 1500,
+  sleepFn = sleep,
+}) {
+  let lastRes = null;
+  const attempts = Math.max(1, maxRetries + 1);
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    lastRes = await readProjectItemsPage({ graphql, projectId: meta.projectId, after: null });
+    const items = lastRes?.node?.items;
+    const nodes = items?.nodes || [];
+    const totalCount = Number(items?.totalCount || 0);
+
+    if (nodes.length > 0) return lastRes;
+
+    if (attempt < attempts) {
+      core.warning(
+        `ProjectV2.items returned zero item nodes (totalCount=${totalCount}) for ${orgLogin} Project #${projectNumber}; retrying (${attempt}/${maxRetries}) before treating the read as authoritative.`
+      );
+      await sleepFn(retryDelayMs);
+    }
+  }
+
+  let membershipSample = [];
+  try {
+    membershipSample = await getRepoProjectMembershipSample({
+      graphql,
+      owner: repositoryOwner,
+      repo: repositoryName,
+      projectNumber,
+    });
+  } catch (e) {
+    core.warning(`Could not run issue-level Project membership consistency check: ${e?.message || e}`);
+  }
+
+  const sampleText = membershipSample.length
+    ? ` Issue-level projectItems still show Project #${projectNumber} membership for: ${membershipSample
+        .slice(0, 5)
+        .map((issue) => `#${issue.number}`)
+        .join(', ')}.`
+    : '';
+
+  core.warning(
+    `ProjectV2.items still returned zero item nodes for ${orgLogin} Project #${projectNumber} after ${attempts} attempts; treating this as a suspect transient/consistency failure and skipping reconcile instead of assuming the project is empty.${sampleText}`
+  );
+
+  return { suspectZeroItems: true, res: lastRes, membershipSample };
+}
+
+async function reconcileProject({
+  graphql,
+  core,
+  meta,
+  orgLogin,
+  projectNumber,
+  repositoryOwner,
+  repositoryName,
+  maxZeroRetries = 2,
+  zeroRetryDelayMs = 1500,
+  sleepFn = sleep,
+}) {
+  core.info(`Reconciling items in ${orgLogin} Project #${projectNumber} (${meta.projectTitle})`);
+
+  let firstPage = await getFirstProjectItemsPageWithRetry({
+    graphql,
+    core,
+    meta,
+    orgLogin,
+    projectNumber,
+    repositoryOwner,
+    repositoryName,
+    maxRetries: maxZeroRetries,
+    retryDelayMs: zeroRetryDelayMs,
+    sleepFn,
+  });
+
+  if (firstPage?.suspectZeroItems) {
+    return { processed: 0, updated: 0, stopped: false, skipped: true, suspectZeroItems: true };
+  }
+
   let after = null;
   let processed = 0;
   let updated = 0;
 
   while (true) {
-    const res = await graphql(query, { projectId: meta.projectId, after });
-    const items = res?.node?.items?.nodes || [];
-    const pageInfo = res?.node?.items?.pageInfo;
+    const res = firstPage || (await readProjectItemsPage({ graphql, projectId: meta.projectId, after }));
+    firstPage = null;
+    const itemsConnection = res?.node?.items;
+    const items = itemsConnection?.nodes || [];
+    const pageInfo = itemsConnection?.pageInfo;
 
     for (const it of items) {
       processed += 1;
@@ -330,7 +459,7 @@ async function reconcileProject({ graphql, core, meta, orgLogin, projectNumber }
 
       if (updated >= 200) {
         core.warning('Safety stop: reached 200 updates in one run.');
-        return { processed, updated, stopped: true };
+        return { processed, updated, stopped: true, skipped: false };
       }
     }
 
@@ -340,11 +469,11 @@ async function reconcileProject({ graphql, core, meta, orgLogin, projectNumber }
     // Safety: don't scan unbounded projects
     if (processed >= 1000) {
       core.warning('Safety stop: scanned 1000 items; stopping.');
-      return { processed, updated, stopped: true };
+      return { processed, updated, stopped: true, skipped: false };
     }
   }
 
-  return { processed, updated, stopped: false };
+  return { processed, updated, stopped: false, skipped: false };
 }
 
 async function run({ github, context, core, env }) {
@@ -367,8 +496,22 @@ async function run({ github, context, core, env }) {
   }
 
   if (reconcile) {
-    const res = await reconcileProject({ graphql, core, meta, orgLogin, projectNumber });
-    core.info(`Reconcile complete. scanned=${res.processed}, updated=${res.updated}, stopped=${res.stopped}`);
+    const repositoryOwner = context.repo?.owner || String(env.GITHUB_REPOSITORY || '').split('/')[0];
+    const repositoryName = context.repo?.repo || String(env.GITHUB_REPOSITORY || '').split('/')[1];
+    const res = await reconcileProject({
+      graphql,
+      core,
+      meta,
+      orgLogin,
+      projectNumber,
+      repositoryOwner,
+      repositoryName,
+      maxZeroRetries: parseRetryCount(env.PROJECT_ITEMS_ZERO_RETRY_COUNT, 2),
+      zeroRetryDelayMs: parseRetryCount(env.PROJECT_ITEMS_ZERO_RETRY_DELAY_MS, 1500),
+    });
+    core.info(
+      `Reconcile complete. scanned=${res.processed}, updated=${res.updated}, stopped=${res.stopped}, skipped=${Boolean(res.skipped)}`
+    );
     return;
   }
 
@@ -410,6 +553,10 @@ module.exports = {
   yyyyMmDd,
   mapProjectFields,
   getProjectMetadata,
+  readProjectItemsPage,
+  getRepoProjectMembershipSample,
+  getFirstProjectItemsPageWithRetry,
+  reconcileProject,
   syncOneItem,
   run,
 };

--- a/docs/ops/project-status-sync.md
+++ b/docs/ops/project-status-sync.md
@@ -43,3 +43,16 @@ Recommended scopes:
 - If no App/PAT token is configured, the workflow fails early with an actionable error.
 - If the closed issue/PR is **not** in org Project #1, the workflow exits successfully (no-op).
 - If the workflow can’t read the project metadata (permissions, renamed fields, etc.), it logs an info message and exits successfully.
+- If scheduled/manual reconciliation sees `ProjectV2.items` return zero items, it treats the read as suspect: retries, checks recent repo issues via issue-level `projectItems`, then skips reconciliation with a warning instead of assuming Project #1 is empty.
+
+## Project item read consistency guard
+
+Issue #301 captured transient GitHub Projects v2 reads where `ProjectV2.items` reported `0` items while issue-level `projectItems` still showed Project #1 membership. The reconciliation path now guards against that case:
+
+1. retry the first zero-item Project read (`PROJECT_ITEMS_ZERO_RETRY_COUNT`, default `2`);
+2. run a read-only issue-level membership sample against recent open issues in the repo;
+3. skip the reconcile run if Project items still read as zero, leaving existing Project fields untouched.
+
+Optional tuning:
+- `PROJECT_ITEMS_ZERO_RETRY_COUNT`: number of retries after the first zero read (default `2`).
+- `PROJECT_ITEMS_ZERO_RETRY_DELAY_MS`: delay between retries (default `1500`).

--- a/docs/ops/projects-v2-auth-runbook.md
+++ b/docs/ops/projects-v2-auth-runbook.md
@@ -192,6 +192,7 @@ gh run list -R "$REPO" --limit 5
 | `actions/create-github-app-token` fails | App not installed on org/repo, or permissions not approved after changes | Install App on Clay-Agency + `novel-task-tracker`; re-approve permissions in installation settings. |
 | GraphQL: `Resource not accessible by integration` | Missing **Org → Projects: Read & write** | Update App permissions, then re-approve installation permissions. |
 | Project not found / can’t resolve `projectV2` | Wrong org login/project number, or token can’t access org project | Confirm workflow env (`ORG_LOGIN`, `PROJECT_NUMBER`) and ensure App is installed on the org. |
+| Scheduled/manual sync warns that `ProjectV2.items` returned zero items after retries | GitHub Projects v2 read inconsistency, auth visibility problem, or genuinely empty Project | Do not restore/delete items based on the zero read alone. Check issue-level `projectItems` on known tracked issues and rerun the workflow/smoke test; the sync skips reconcile to avoid treating Project #1 as empty. |
 | Some project items never update | Project includes items from repos not covered by installation | Install App on those repos or broaden installation scope. |
 | PEM-related errors | PEM pasted without headers/line breaks | Re-set `PROJECTS_APP_PRIVATE_KEY` with the raw PEM text. |
 

--- a/src/ops/projectStatusSync.test.ts
+++ b/src/ops/projectStatusSync.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { getProjectMetadata, syncOneItem, schemaHelp } = require('../../.github/scripts/project-status-sync.cjs');
+const { getProjectMetadata, getFirstProjectItemsPageWithRetry, reconcileProject, syncOneItem, schemaHelp } = require('../../.github/scripts/project-status-sync.cjs');
 
 describe('project-status-sync', () => {
   it('maps Status/Done date/Needs decision fields from project metadata (incl. Done option id)', async () => {
@@ -337,5 +337,142 @@ describe('project-status-sync', () => {
     expect(msg).toContain(schemaHelp());
     expect(msg).toContain('Maybe');
   });
+
+  it('retries and skips reconcile when ProjectV2.items repeatedly reports zero items', async () => {
+    const graphql = vi.fn(async (query: string) => {
+      if (query.includes('repository(owner:')) {
+        return {
+          repository: {
+            issues: {
+              nodes: [
+                {
+                  number: 301,
+                  url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/301',
+                  projectItems: { nodes: [{ project: { number: 1 } }] },
+                },
+              ],
+            },
+          },
+        };
+      }
+
+      return {
+        node: {
+          items: {
+            totalCount: 0,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [],
+          },
+        },
+      };
+    });
+
+    const core = { info: vi.fn(), warning: vi.fn() };
+    const res = await reconcileProject({
+      graphql,
+      core,
+      meta: { projectId: 'P1', projectTitle: 'Clay Project' },
+      orgLogin: 'Clay-Agency',
+      projectNumber: 1,
+      repositoryOwner: 'Clay-Agency',
+      repositoryName: 'novel-task-tracker',
+      maxZeroRetries: 2,
+      zeroRetryDelayMs: 0,
+      sleepFn: vi.fn(async () => undefined),
+    });
+
+    expect(res).toEqual({ processed: 0, updated: 0, stopped: false, skipped: true, suspectZeroItems: true });
+    // 3 project item attempts + 1 issue-level consistency check.
+    expect(graphql).toHaveBeenCalledTimes(4);
+    expect(core.warning.mock.calls.map((call) => String(call[0])).join('\n')).toContain(
+      'treating this as a suspect transient/consistency failure and skipping reconcile'
+    );
+    expect(core.warning.mock.calls.map((call) => String(call[0])).join('\n')).toContain('#301');
+  });
+
+  it('continues reconcile when a zero ProjectV2.items read recovers on retry', async () => {
+    let projectReadCount = 0;
+    const graphql = vi.fn(async (query: string) => {
+      if (!query.includes('items(first: 50')) return {};
+      projectReadCount += 1;
+
+      if (projectReadCount === 1) {
+        return {
+          node: {
+            items: {
+              totalCount: 0,
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [],
+            },
+          },
+        };
+      }
+
+      return {
+        node: {
+          items: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                id: 'ITEM1',
+                content: {
+                  __typename: 'Issue',
+                  url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/1',
+                  state: 'OPEN',
+                  closedAt: null,
+                },
+              },
+            ],
+          },
+        },
+      };
+    });
+
+    const core = { info: vi.fn(), warning: vi.fn() };
+    const res = await reconcileProject({
+      graphql,
+      core,
+      meta: { projectId: 'P1', projectTitle: 'Clay Project' },
+      orgLogin: 'Clay-Agency',
+      projectNumber: 1,
+      maxZeroRetries: 2,
+      zeroRetryDelayMs: 0,
+      sleepFn: vi.fn(async () => undefined),
+    });
+
+    expect(res).toEqual({ processed: 1, updated: 0, stopped: false, skipped: false });
+    expect(projectReadCount).toBe(2);
+    expect(core.warning.mock.calls.map((call) => String(call[0])).join('\n')).toContain('retrying (1/2)');
+  });
+
+  it('returns the first ProjectV2.items page immediately when item nodes are present', async () => {
+    const graphql = vi.fn(async () => ({
+      node: {
+        items: {
+          totalCount: 1,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [{ id: 'ITEM1' }],
+        },
+      },
+    }));
+    const core = { warning: vi.fn() };
+
+    const res = await getFirstProjectItemsPageWithRetry({
+      graphql,
+      core,
+      meta: { projectId: 'P1' },
+      orgLogin: 'Clay-Agency',
+      projectNumber: 1,
+      maxRetries: 2,
+      retryDelayMs: 0,
+      sleepFn: vi.fn(async () => undefined),
+    });
+
+    expect(res.suspectZeroItems).toBeUndefined();
+    expect(graphql).toHaveBeenCalledTimes(1);
+    expect(core.warning).not.toHaveBeenCalled();
+  });
+
 
 });


### PR DESCRIPTION
## Summary
- guard scheduled/manual Project #1 reconciliation against suspect empty `ProjectV2.items` reads
- retry zero-item-node first pages, sample issue-level `projectItems`, and skip reconcile instead of treating Project #1 as empty
- document the consistency guard and troubleshooting note for Issue #301

## Tests
- `npm test -- --run src/ops/projectStatusSync.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run check:workflows`

Fixes #301
