### PR TITLE
Harden needs-decision snapshot label lookup

### DIFF
--- a/.github/scripts/needs-decision-snapshot-lib.ts
+++ b/.github/scripts/needs-decision-snapshot-lib.ts
@@ -6,6 +6,7 @@ export type GitHubSearchItem = {
   updated_at?: string;
   created_at?: string;
   pull_request?: unknown;
+  labels?: Array<{ name?: string } | string>;
 };
 
 export const SNAPSHOT_TITLE = 'Needs-decision snapshot (automated)';

--- a/.github/scripts/needs-decision-snapshot.ts
+++ b/.github/scripts/needs-decision-snapshot.ts
@@ -69,6 +69,35 @@ async function ghFetch<T>(path: string, init?: RequestInit): Promise<T> {
   return (await res.json()) as T;
 }
 
+
+function hasLabel(item: GitHubSearchItem, label: string): boolean {
+  return (item.labels || []).some((it) => {
+    if (typeof it === 'string') return it === label;
+    return it.name === label;
+  });
+}
+
+async function listOpenItemsWithLabel(owner: string, repo: string, label: string, maxPages = 10): Promise<GitHubSearchItem[]> {
+  const perPage = 100;
+  const items: GitHubSearchItem[] = [];
+
+  for (let page = 1; page <= maxPages; page += 1) {
+    const pageItems = await ghFetch<GitHubSearchItem[]>(
+      `/repos/${owner}/${repo}/issues?state=open&per_page=${perPage}&page=${page}`
+    );
+
+    items.push(...pageItems.filter((item) => hasLabel(item, label)));
+
+    if (pageItems.length < perPage) break;
+  }
+
+  return items.sort((a, b) => {
+    const bTime = Date.parse(b.updated_at || '');
+    const aTime = Date.parse(a.updated_at || '');
+    return (Number.isNaN(bTime) ? 0 : bTime) - (Number.isNaN(aTime) ? 0 : aTime);
+  });
+}
+
 async function searchAllIssues(query: string, maxPages = 10): Promise<GitHubSearchItem[]> {
   const perPage = 100;
   const items: GitHubSearchItem[] = [];
@@ -238,8 +267,7 @@ export async function main(): Promise<void> {
       ? `${process.env.GITHUB_SERVER_URL}/${repoFull}/actions/runs/${process.env.GITHUB_RUN_ID}`
       : undefined;
 
-  const q = `repo:${repoFull} is:open label:"${LABEL}" sort:updated-desc`;
-  const all = await searchAllIssues(q, 10);
+  const all = await listOpenItemsWithLabel(owner, repo, LABEL, 10);
   const { prs, issues } = splitPrsAndIssues(all);
 
   const body = buildBody({ repoFull, runUrl, generatedAt: new Date(), prs, issues });

--- a/test/needs-decision-snapshot.test.ts
+++ b/test/needs-decision-snapshot.test.ts
@@ -40,6 +40,10 @@ describe('needs-decision snapshot script', () => {
       const method = (init?.method || 'GET').toUpperCase();
       calls.push({ url: u.toString(), init });
 
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues' && method === 'GET') {
+        return okJson([]);
+      }
+
       if (path === '/search/issues' && method === 'GET') {
         const q = u.searchParams.get('q') || '';
         // First query: open items labeled needs-decision
@@ -110,6 +114,10 @@ describe('needs-decision snapshot script', () => {
       const method = (init?.method || 'GET').toUpperCase();
       calls.push({ url: u.toString(), init });
 
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues' && method === 'GET') {
+        return okJson([]);
+      }
+
       if (path === '/search/issues' && method === 'GET') {
         const q = u.searchParams.get('q') || '';
         // First query: open items labeled needs-decision
@@ -179,6 +187,10 @@ describe('needs-decision snapshot script', () => {
       const path = u.pathname;
       const method = (init?.method || 'GET').toUpperCase();
       calls.push({ url: u.toString(), init });
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues' && method === 'GET') {
+        return okJson([]);
+      }
 
       if (path === '/search/issues' && method === 'GET') {
         const q = u.searchParams.get('q') || '';
@@ -264,6 +276,83 @@ describe('needs-decision snapshot script', () => {
 
     const commentCalls = calls.filter((c) => c.url.includes('/issues/60/comments'));
     expect(commentCalls.length).toBe(1);
+  });
+
+
+  it('builds snapshot items from unfiltered open issues client-side filtered by needs-decision and sorted by updated_at', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    let patchedBody = '';
+
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const u = new URL(String(url));
+      const path = u.pathname;
+      const method = (init?.method || 'GET').toUpperCase();
+      calls.push({ url: u.toString(), init });
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues' && method === 'GET') {
+        expect(u.searchParams.get('state')).toBe('open');
+        expect(u.searchParams.has('labels')).toBe(false);
+        return okJson([
+          {
+            number: 10,
+            title: 'older decision',
+            html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/10',
+            user: { login: 'alice' },
+            updated_at: '2026-04-01T00:00:00Z',
+            labels: [{ name: 'needs-decision' }],
+          },
+          {
+            number: 11,
+            title: 'not a decision',
+            html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/11',
+            user: { login: 'bob' },
+            updated_at: '2026-04-03T00:00:00Z',
+            labels: [{ name: 'bug' }],
+          },
+          {
+            number: 12,
+            title: 'newer decision PR',
+            html_url: 'https://github.com/Clay-Agency/novel-task-tracker/pull/12',
+            user: { login: 'carol' },
+            updated_at: '2026-04-04T00:00:00Z',
+            labels: [{ name: 'needs-decision' }],
+            pull_request: {},
+          },
+        ]);
+      }
+
+      if (path === '/search/issues' && method === 'GET') {
+        const q = u.searchParams.get('q') || '';
+        expect(q).not.toContain('label:"needs-decision"');
+        if (q.includes('in:title') && q.includes('Needs-decision snapshot (automated)')) {
+          return okJson({ total_count: 1, incomplete_results: false, items: [{ number: 50, title: 'Needs-decision snapshot (automated)', html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/50' }] });
+        }
+        throw new Error(`Unexpected search query: ${q}`);
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/50' && method === 'GET') {
+        return okJson({ number: 50, title: 'Needs-decision snapshot (automated)', state: 'open', html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/50', body: 'x' });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/50' && method === 'PATCH') {
+        patchedBody = String(JSON.parse(String(init?.body || '{}')).body || '');
+        return okJson({ number: 50, title: 'Needs-decision snapshot (automated)', state: 'open', html_url: 'https://github.com/Clay-Agency/novel-task-tracker/issues/50', body: patchedBody });
+      }
+
+      if (path === '/repos/Clay-Agency/novel-task-tracker/issues/50/labels' && method === 'POST') {
+        return okJson([{ name: 'automation' }]);
+      }
+
+      throw new Error(`Unexpected fetch: ${method} ${path}`);
+    }) as unknown as typeof fetch;
+
+    await main();
+
+    expect(patchedBody).toContain('Open items labeled `needs-decision`: **2** (PRs: **1**, issues: **1**)');
+    expect(patchedBody).toContain('newer decision PR');
+    expect(patchedBody).toContain('older decision');
+    expect(patchedBody).not.toContain('not a decision');
+    expect(calls.some((c) => new URL(c.url).pathname === '/search/issues' && (new URL(c.url).searchParams.get('q') || '').includes('label:"needs-decision"'))).toBe(false);
   });
 
 });


### PR DESCRIPTION
## Summary
- Replace the snapshot body item query with unfiltered paginated REST open issues/PRs
- Client-side filter canonical `needs-decision` labels and sort by `updated_at` descending
- Keep search-based title lookup only for finding/closing automated snapshot issues

Closes #303

## Verification
- npm run lint
- npm run typecheck
- npm test
- `GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=Clay-Agency/novel-task-tracker DRY_RUN=true SNAPSHOT_ISSUE_NUMBER=277 node .github/scripts-dist/needs-decision-snapshot.js` reported 6 issues (#299/#276/#260/#214/#80/#126)
